### PR TITLE
Handle Unknown output datatype with string as default

### DIFF
--- a/changelog/@unreleased/pr-5.v2.yml
+++ b/changelog/@unreleased/pr-5.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Handle Unknown output datatype with string as default
+  links:
+  - https://github.com/palantir/python-compute-module/pull/5

--- a/compute_modules/function_registry/function_schema_parser.py
+++ b/compute_modules/function_registry/function_schema_parser.py
@@ -95,8 +95,7 @@ def _default_unknown_output() -> FunctionOutputType:
         type="single",
         single={
             "dataType": {
-                "type": "unknown",
-                "unknown": {},
+                "type": "string",
             },
         },
     )

--- a/compute_modules/function_registry/function_schema_parser.py
+++ b/compute_modules/function_registry/function_schema_parser.py
@@ -91,6 +91,10 @@ def _extract_inputs(
 
 
 def _default_unknown_output() -> FunctionOutputType:
+    """
+    The UI for compute modules throws an error when registering a function without output, or with an output type that
+    it does not recognize. To align with the behavior of other services, we should default the output type to a string.
+    """
     return FunctionOutputType(
         type="single",
         single={

--- a/tests/function_registry/test_function_schema_parser.py
+++ b/tests/function_registry/test_function_schema_parser.py
@@ -142,8 +142,7 @@ def test_function_schema_parser_no_type_hints() -> None:
             type="single",
             single={
                 "dataType": {
-                    "type": "unknown",
-                    "unknown": {},
+                    "type": "string",
                 },
             },
         ),


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

The UI for compute modules throws an error when registering a function with an unknown type because the registry does not recognize this data type. To align with the behavior of other services, we should default the output type to a string.
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Handle Unknown output datatype with string as default
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

## Are Docs needed?
<!-- Please indicate whether documentation is needed for this PR. -->
