### PR TITLE
Remove executable scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - checkout
       - run: poetry install
-      - run: poetry run test
+      - run: python -m scripts.checks test
 
   mypy:
     docker:
@@ -25,7 +25,7 @@ jobs:
     steps:
       - checkout
       - run: poetry install
-      - run: poetry run check_mypy
+      - run: python -m scripts.checks test check_mypy
 
   check_format:
     docker:
@@ -33,7 +33,7 @@ jobs:
     steps:
       - checkout
       - run: poetry install
-      - run: poetry run check_format
+      - run: python -m scripts.checks check_format
 
   check_license:
     docker:
@@ -41,7 +41,7 @@ jobs:
     steps:
       - checkout
       - run: poetry install
-      - run: poetry run check_license
+      - run: python -m scripts.checks check_license
 
   circle-all:
     docker:
@@ -55,7 +55,7 @@ jobs:
     steps:
       - checkout
       - run: poetry install
-      - run: poetry run set_version
+      - run: python -m scripts.checks set_version
       - run: poetry publish -v -u $PYPI_USERNAME -p $PYPI_PASSWORD --build
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - checkout
       - run: poetry install
-      - run: python -m scripts.checks test
+      - run: poetry run python -c 'from scripts.checks import test; test()'
 
   mypy:
     docker:
@@ -25,7 +25,7 @@ jobs:
     steps:
       - checkout
       - run: poetry install
-      - run: python -m scripts.checks test check_mypy
+      - run: poetry run python -c 'from scripts.checks import check_mypy; check_mypy()'
 
   check_format:
     docker:
@@ -33,7 +33,7 @@ jobs:
     steps:
       - checkout
       - run: poetry install
-      - run: python -m scripts.checks check_format
+      - run: poetry run python -c 'from scripts.checks import check_format; check_format()'
 
   check_license:
     docker:
@@ -41,7 +41,7 @@ jobs:
     steps:
       - checkout
       - run: poetry install
-      - run: python -m scripts.checks check_license
+      - run: poetry run python -c 'from scripts.checks import check_license; check_license()'
 
   circle-all:
     docker:
@@ -55,7 +55,7 @@ jobs:
     steps:
       - checkout
       - run: poetry install
-      - run: python -m scripts.checks set_version
+      - run: poetry run python -c 'from scripts.checks import set_version; set_version()'
       - run: poetry publish -v -u $PYPI_USERNAME -p $PYPI_PASSWORD --build
 
 workflows:

--- a/changelog/@unreleased/pr-11.v2.yml
+++ b/changelog/@unreleased/pr-11.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Remove executable scripts
+  links:
+  - https://github.com/palantir/python-compute-module/pull/11

--- a/compute_modules/auth/third_party.py
+++ b/compute_modules/auth/third_party.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 
-
 import http.client
 import json
 import os

--- a/compute_modules/auth/third_party.py
+++ b/compute_modules/auth/third_party.py
@@ -1,3 +1,18 @@
+#  Copyright 2024 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
 
 import http.client
 import json

--- a/compute_modules/auth/third_party.py
+++ b/compute_modules/auth/third_party.py
@@ -1,17 +1,3 @@
-#  Copyright 2024 Palantir Technologies, Inc.
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-
 
 import http.client
 import json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,15 +25,6 @@ pytest-html = "4.1.1"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.poetry.scripts]
-test = "scripts.checks:test"
-check_format = "scripts.checks:check_format"
-check_mypy = "scripts.checks:check_mypy"
-format = "scripts.checks:format"
-check_license = "scripts.checks:check_license"
-license = "scripts.checks:license"
-set_version = "scripts.set_version:main"
-
 [tool.black]
 line_length = 120
 

--- a/scripts/checks.py
+++ b/scripts/checks.py
@@ -1,3 +1,18 @@
+#  Copyright 2024 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
 
 import shutil
 import subprocess
@@ -110,6 +125,7 @@ def license() -> None:
         if not file_head.startswith(expected_license_content):
             _add_license_to_file(filepath=filename, license_content=expected_license_content)
             updated_files.append(filename)
+
     if updated_files:
         print(f"Added license to the following files:\n\n{_get_files_list_str(updated_files)}")
     else:

--- a/scripts/checks.py
+++ b/scripts/checks.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 
-
 import shutil
 import subprocess
 import sys

--- a/scripts/checks.py
+++ b/scripts/checks.py
@@ -1,17 +1,3 @@
-#  Copyright 2024 Palantir Technologies, Inc.
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-
 
 import shutil
 import subprocess


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

poetry scripts turns the python function into an executable and this cannot allow windows 64 to publish this PyPi as a  conda forge https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1064769&view=logs&j=53c3d5f4-e7c7-5b53-4b94-211701b2ba17&t=8f042650-8479-5761-7a4a-8d021c0bb2de&l=1807
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Remove executable scripts
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

## Are Docs needed?
<!-- Please indicate whether documentation is needed for this PR. -->
