### PR TITLE
Use process pool for executing tasks & use requests.Session to re-use connections

### DIFF
--- a/changelog/@unreleased/pr-17.v2.yml
+++ b/changelog/@unreleased/pr-17.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: 'Performance improvements: process pooling; reusing connections'
+  links:
+  - https://github.com/palantir/python-compute-module/pull/17

--- a/compute_modules/client/internal_query_client.py
+++ b/compute_modules/client/internal_query_client.py
@@ -22,7 +22,6 @@ from typing import Any, Callable, Dict, Iterable, List
 from urllib.parse import urlparse
 
 import requests
-from requests.adapters import HTTPAdapter
 
 from compute_modules.context.types import QueryContext
 from compute_modules.function_registry.function_payload_converter import convert_payload
@@ -39,17 +38,6 @@ POST_SCHEMAS_MAX_ATTEMPTS = 5
 def _extract_path_from_url(url: str) -> str:
     parsed_url = urlparse(url)
     return parsed_url.path
-
-
-class SSLContextAdapter(HTTPAdapter):  # type: ignore[misc]
-    # TODO: do we need this or can we use verify=self.certPath
-    def __init__(self, ssl_context: ssl.SSLContext, **kwargs):  # type: ignore[no-untyped-def]
-        self.ssl_context = ssl_context
-        super().__init__(**kwargs)
-
-    def init_poolmanager(self, *args, **kwargs):  # type: ignore[no-untyped-def]
-        kwargs["ssl_context"] = self.ssl_context
-        return super().init_poolmanager(*args, **kwargs)
 
 
 class InternalQueryService:
@@ -115,8 +103,6 @@ class InternalQueryService:
     def init_session(self) -> None:
         """Initialize requests.Session"""
         self.session = requests.Session()
-        adapter = SSLContextAdapter(ssl_context=self.context)
-        self.session.mount("https://", adapter)
 
     def build_url(self, path: str) -> str:
         return f"https://{self.host}:{self.port}{path}"
@@ -131,6 +117,7 @@ class InternalQueryService:
                     url=self.build_url(self.post_schema_path),
                     json=self.function_schemas,
                     headers=self.post_schema_headers,
+                    verify=self.certPath,
                 ) as response:
                     self.logger.debug(
                         f"POST /schemas response status: {response.status_code} reason: {response.reason}"
@@ -151,6 +138,7 @@ class InternalQueryService:
                 method="GET",
                 url=self.build_url(self.get_job_path),
                 headers=self.get_job_headers,
+                verify=self.certPath,
             ) as response:
                 result = None
                 if response.status_code == 200:
@@ -182,6 +170,7 @@ class InternalQueryService:
                     url=post_result_url,
                     headers=self.post_result_headers,
                     data=body,
+                    verify=self.certPath,
                 ) as response:
                     if response.status_code == 204:
                         self.logger.debug("Successfully reported job result")

--- a/compute_modules/client/internal_query_client.py
+++ b/compute_modules/client/internal_query_client.py
@@ -15,7 +15,6 @@
 
 import http.client
 import json
-import multiprocessing
 import os
 import ssl
 import time
@@ -199,16 +198,8 @@ class InternalQueryService:
                 self.logger.error(traceback.format_exc())
         raise RuntimeError(f"Unable to post job result after {POST_RESULT_MAX_ATTEMPTS} attempts")
 
-    def handle_query(self) -> None:
-        job = None
-        try:
-            job = self.get_job_or_none()
-        except Exception as e:
-            self.logger.warning(f"Exception occurred while fetching job: {str(e)}")
-        if job:
-            self.handle_job(job)
-
     def handle_job(self, job: Dict[str, Any]) -> None:
+        self.logger.info("handling job")
         v1 = job.get("computeModuleJobV1", {})
         job_id = v1.get("jobId")
         query_type = v1.get("queryType")
@@ -265,18 +256,3 @@ class InternalQueryService:
     @staticmethod
     def get_failed_query(exception: Exception) -> Dict[str, str]:
         return {"exception": f"{str(exception)}: {traceback.format_exc()}"}
-
-    def start(self) -> None:
-        self.post_query_schemas()
-        self.logger.info(f"Starting to poll for jobs with concurrency {self.concurrency}")
-        processes = [multiprocessing.Process(target=self.poll_forever, args=(i,)) for i in range(self.concurrency)]
-        for p in processes:
-            p.start()
-        for p in processes:
-            p.join()
-
-    def poll_forever(self, process_id: int) -> None:
-        self._set_logger_process_id(process_id=process_id)
-        while True:
-            self.logger.info("Polling for new jobs...")
-            self.handle_query()

--- a/compute_modules/client/internal_query_client.py
+++ b/compute_modules/client/internal_query_client.py
@@ -13,15 +13,16 @@
 #  limitations under the License.
 
 
-import http.client
 import json
 import os
 import ssl
 import time
 import traceback
-from contextlib import contextmanager
-from typing import Any, Callable, Dict, Generator, Iterable, List, Optional
+from typing import Any, Callable, Dict, Iterable, List
 from urllib.parse import urlparse
+
+import requests
+from requests.adapters import HTTPAdapter
 
 from compute_modules.context.types import QueryContext
 from compute_modules.function_registry.function_payload_converter import convert_payload
@@ -38,6 +39,17 @@ POST_SCHEMAS_MAX_ATTEMPTS = 5
 def _extract_path_from_url(url: str) -> str:
     parsed_url = urlparse(url)
     return parsed_url.path
+
+
+class SSLContextAdapter(HTTPAdapter):  # type: ignore[misc]
+    # TODO: do we need this or can we use verify=self.certPath
+    def __init__(self, ssl_context: ssl.SSLContext, **kwargs):  # type: ignore[no-untyped-def]
+        self.ssl_context = ssl_context
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        kwargs["ssl_context"] = self.ssl_context
+        return super().init_poolmanager(*args, **kwargs)
 
 
 class InternalQueryService:
@@ -66,6 +78,7 @@ class InternalQueryService:
         self.connection_refused_count: int = 0
         self.concurrency = int(os.environ.get("MAX_CONCURRENT_TASKS", 1))
         self.logger = get_internal_logger()
+        self.init_session()
 
     def _clear_logger_job_id(self) -> None:
         """Clear the _job_logger until we receive another job"""
@@ -99,49 +112,31 @@ class InternalQueryService:
         for i in iterable:
             yield json.dumps(i).encode("utf-8")
 
-    @contextmanager
-    def request(
-        self,
-        method: str,
-        url: str,
-        headers: Dict[str, Any],
-        body: Optional[Any] = None,
-    ) -> Generator[http.client.HTTPResponse, Any, None]:
-        """Wrapper for using https connection for requests"""
-        response: Optional[http.client.HTTPResponse] = None
-        connection = http.client.HTTPSConnection(
-            host=self.host,
-            port=self.port,
-            context=self.context,
-            timeout=(60 * 5),  # 5 minutes
-        )
-        try:
-            connection.request(
-                method=method,
-                url=url,
-                body=body,
-                headers=headers,
-            )
-            response = connection.getresponse()
-            yield response
-        finally:
-            connection.close()
+    def init_session(self) -> None:
+        """Initialize requests.Session"""
+        self.session = requests.Session()
+        adapter = SSLContextAdapter(ssl_context=self.context)
+        self.session.mount("https://", adapter)
+
+    def build_url(self, path: str) -> str:
+        return f"https://{self.host}:{self.port}{path}"
 
     def post_query_schemas(self) -> None:
         """Post the function schemas of the Compute Module"""
-        body = json.dumps(self.function_schemas)
-        self.logger.debug(f"Posting function schemas: {body}")
+        self.logger.debug(f"Posting function schemas: {self.function_schemas}")
         for i in range(POST_SCHEMAS_MAX_ATTEMPTS):
             try:
-                with self.request(
+                with self.session.request(
                     method="POST",
-                    url=self.post_schema_path,
-                    body=body,
+                    url=self.build_url(self.post_schema_path),
+                    json=self.function_schemas,
                     headers=self.post_schema_headers,
                 ) as response:
-                    self.logger.debug(f"POST /schemas response status: {response.status} reason: {response.reason}")
+                    self.logger.debug(
+                        f"POST /schemas response status: {response.status_code} reason: {response.reason}"
+                    )
                 return
-            except ConnectionRefusedError:
+            except (ConnectionRefusedError, requests.exceptions.ConnectionError):
                 self.logger.warning(f"POST /schemas attempt #{i+1} Connection refused. Sleeping for {2 ** i}s")
                 time.sleep(2**i)
             except Exception as e:
@@ -152,18 +147,21 @@ class InternalQueryService:
 
     def get_job_or_none(self) -> Any:
         try:
-            with self.request(method="GET", url=self.get_job_path, headers=self.get_job_headers) as response:
-                response_data = response.read().decode()
+            with self.session.request(
+                method="GET",
+                url=self.build_url(self.get_job_path),
+                headers=self.get_job_headers,
+            ) as response:
                 result = None
-                if response.status == 200:
-                    result = json.loads(response_data)
-                elif response.status == 204:
+                if response.status_code == 200:
+                    result = response.json()
+                elif response.status_code == 204:
                     self.logger.info("No job found, retrying...")
                 else:
-                    self.logger.error(f"Unexpected response status: {response.status}")
+                    self.logger.error(f"Unexpected response status: {response.status_code}")
                 self.connection_refused_count = 0
                 return result
-        except ConnectionRefusedError:
+        except (ConnectionRefusedError, requests.exceptions.ConnectionError):
             self.logger.warning(f"Connection refused. Sleeping for {2 ** self.connection_refused_count}s")
             time.sleep(2**self.connection_refused_count)
             self.connection_refused_count += 1
@@ -175,20 +173,21 @@ class InternalQueryService:
 
     def report_job_result(self, job_id: str, body: Any) -> None:
         post_result_path = f"{self.post_result_path}/{job_id}"
-        self.logger.debug(f"Posting result to {post_result_path}")
+        post_result_url = self.build_url(post_result_path)
+        self.logger.debug(f"Posting result to {post_result_url}")
         for _ in range(POST_RESULT_MAX_ATTEMPTS):
             try:
-                with self.request(
+                with self.session.request(
                     method="POST",
-                    url=post_result_path,
+                    url=post_result_url,
                     headers=self.post_result_headers,
-                    body=body,
+                    data=body,
                 ) as response:
-                    if response.status == 204:
+                    if response.status_code == 204:
                         self.logger.debug("Successfully reported job result")
                         return
                     else:
-                        self.logger.error(f"Failed to post result: {response.status} {response.reason}")
+                        self.logger.error(f"Failed to post result: {response.status_code} {response.reason}")
             except TypeError as e:
                 self.logger.error(f"Failed to serialize result to json: {str(e)}")
                 self.report_job_result(job_id, json.dumps(self.get_failed_query(e)).encode("utf-8"))

--- a/compute_modules/logging/common.py
+++ b/compute_modules/logging/common.py
@@ -29,7 +29,7 @@ else:
 
 # TODO: add replica ID to default log format
 DEFAULT_LOG_FORMAT = (
-    "%(levelname)-8s PID: %(process_id)-2s JOB: %(job_id)-36s LOC: %(filename)s:%(lineno)d - %(message)s"
+    "%(levelname)-8s PID: %(process_id)-6s JOB: %(job_id)-36s LOC: %(filename)s:%(lineno)d - %(message)s"
 )
 
 

--- a/compute_modules/startup.py
+++ b/compute_modules/startup.py
@@ -13,6 +13,10 @@
 #  limitations under the License.
 
 
+import os
+from multiprocessing.pool import Pool
+from typing import Any, Dict, Optional
+
 from compute_modules.client.internal_query_client import InternalQueryService
 from compute_modules.function_registry.function_registry import (
     FUNCTION_SCHEMA_CONVERSIONS,
@@ -22,14 +26,46 @@ from compute_modules.function_registry.function_registry import (
     STREAMING,
 )
 
+QUERY_CLIENT: Optional[InternalQueryService] = None
+
+
+def _handle_job(job: Dict[str, Any]) -> None:
+    """Helper function to be called by pool.apply_async since python can't serialize methods"""
+    global QUERY_CLIENT
+    assert QUERY_CLIENT, "QUERY_CLIENT is uninitialized"
+    QUERY_CLIENT.logger.info("Inside the worker process")
+    QUERY_CLIENT._set_logger_process_id(process_id=os.getpid())
+    QUERY_CLIENT.logger.info(f"trying to handle the job... {job}")
+    QUERY_CLIENT.handle_job(job=job)
+
+
+def _get_and_schedule_job(pool: Pool) -> None:
+    """Try to get a job and schedule to the process pool"""
+    global QUERY_CLIENT
+    assert QUERY_CLIENT, "QUERY_CLIENT is uninitialized"
+    job = None
+    try:
+        job = QUERY_CLIENT.get_job_or_none()
+    except Exception as e:
+        QUERY_CLIENT.logger.warning(f"Exception occurred while fetching job: {str(e)}")
+    if job:
+        QUERY_CLIENT.logger.debug(f"Got a job: {job}")
+        pool.apply_async(_handle_job, (job,))
+
 
 def start_compute_module() -> None:
     """Starts a Compute Module that will Poll for jobs indefinitely"""
-    query_client = InternalQueryService(
+    global QUERY_CLIENT
+    QUERY_CLIENT = InternalQueryService(
         registered_functions=REGISTERED_FUNCTIONS,
         function_schemas=FUNCTION_SCHEMAS,
         function_schema_conversions=FUNCTION_SCHEMA_CONVERSIONS,
         is_function_context_typed=IS_FUNCTION_CONTEXT_TYPED,
         streaming=STREAMING,
     )
-    query_client.start()
+    QUERY_CLIENT.post_query_schemas()
+    QUERY_CLIENT.logger.info(f"Starting to poll for jobs with concurrency {QUERY_CLIENT.concurrency}")
+    with Pool(QUERY_CLIENT.concurrency) as pool:
+        while True:
+            QUERY_CLIENT.logger.info("Polling for new jobs...")
+            _get_and_schedule_job(pool)

--- a/compute_modules/startup.py
+++ b/compute_modules/startup.py
@@ -28,6 +28,18 @@ from compute_modules.function_registry.function_registry import (
 
 QUERY_CLIENT: Optional[InternalQueryService] = None
 
+# The main process creates the initial InternalQueryService instance,
+# which is used to post the function schema and poll for jobs.
+#
+# We then spin up a Pool of worker processes that all create their own sessions.
+# When a job is received by the main process, that job is delegated to a worker.
+# The worker then processes that job and posts the result back to the runtime using its own session.
+#
+# This library supports streaming responses via generators.
+# Python passes data between processes by using `pickle` to serialize the data.
+# Generators cannot be pickled, so we cannot pass the result of streaming functions back to the parent process.
+# As a workaround, the worker process is given a session only for posting job results back to the runtime.
+
 
 def _handle_job(job: Dict[str, Any]) -> None:
     """Helper function to be called by pool.apply_async since python can't serialize methods"""

--- a/compute_modules/startup.py
+++ b/compute_modules/startup.py
@@ -33,9 +33,6 @@ def _handle_job(job: Dict[str, Any]) -> None:
     """Helper function to be called by pool.apply_async since python can't serialize methods"""
     global QUERY_CLIENT
     assert QUERY_CLIENT, "QUERY_CLIENT is uninitialized"
-    QUERY_CLIENT.logger.info("Inside the worker process")
-    QUERY_CLIENT._set_logger_process_id(process_id=os.getpid())
-    QUERY_CLIENT.logger.info(f"trying to handle the job... {job}")
     QUERY_CLIENT.handle_job(job=job)
 
 
@@ -53,6 +50,14 @@ def _get_and_schedule_job(pool: Pool) -> None:
         pool.apply_async(_handle_job, (job,))
 
 
+def _worker_init() -> None:
+    """Create a new session for each worker"""
+    global QUERY_CLIENT
+    assert QUERY_CLIENT, "QUERY_CLIENT is uninitialized"
+    QUERY_CLIENT.init_session()
+    QUERY_CLIENT._set_logger_process_id(os.getpid())
+
+
 def start_compute_module() -> None:
     """Starts a Compute Module that will Poll for jobs indefinitely"""
     global QUERY_CLIENT
@@ -65,7 +70,7 @@ def start_compute_module() -> None:
     )
     QUERY_CLIENT.post_query_schemas()
     QUERY_CLIENT.logger.info(f"Starting to poll for jobs with concurrency {QUERY_CLIENT.concurrency}")
-    with Pool(QUERY_CLIENT.concurrency) as pool:
+    with Pool(QUERY_CLIENT.concurrency, initializer=_worker_init) as pool:
         while True:
             QUERY_CLIENT.logger.info("Polling for new jobs...")
             _get_and_schedule_job(pool)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ mypy = "1.9.0"
 ruff = "0.2.1"
 pytest = "8.0.0"
 pytest-html = "4.1.1"
+types-requests = "^2.32.0.20241016"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ packages = [{ include = "compute_modules" }]
 
 [tool.poetry.dependencies]
 python = "^3.9"
+requests = "^2.32.3"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/logging/test_log_context.py
+++ b/tests/logging/test_log_context.py
@@ -29,6 +29,8 @@ from .logging_test_utils import CLIENT_INFO_STR, CLIENT_WARNING_STR, INFO_STR
 
 logging.basicConfig(format=DEFAULT_LOG_FORMAT)
 
+PROCESS_ID = 12345
+
 
 def logger_fixtures() -> tuple[ComputeModulesLoggerAdapter, ComputeModulesLoggerAdapter, ComputeModulesLoggerAdapter]:
     """Initializes & configures loggers"""
@@ -42,7 +44,7 @@ def logger_fixtures() -> tuple[ComputeModulesLoggerAdapter, ComputeModulesLogger
 
 
 def format_log_context(pid: int, job_id: str) -> str:
-    return f"PID: {pid:<2} JOB: {job_id:<37}"
+    return f"PID: {pid:<6} JOB: {job_id:<37}"
 
 
 def test_initial_log_format(
@@ -58,7 +60,7 @@ def test_initial_log_format(
     assert len(parsed_out) == 3
     for log in parsed_out:
         assert format_log_context(pid=-1, job_id="") in log
-    COMPUTE_MODULES_ADAPTER_MANAGER.update_process_id(process_id=2)
+    COMPUTE_MODULES_ADAPTER_MANAGER.update_process_id(process_id=PROCESS_ID)
     internal_logger.info(INFO_STR)
     logger_1.info(CLIENT_INFO_STR)
     logger_2.info(CLIENT_WARNING_STR)
@@ -66,7 +68,7 @@ def test_initial_log_format(
     parsed_out = list(filter(lambda x: x, captured.err.split("\n")))
     assert len(parsed_out) == 3
     for log in parsed_out:
-        assert format_log_context(pid=2, job_id="") in log
+        assert format_log_context(pid=PROCESS_ID, job_id="") in log
     job_id = str(uuid.uuid4())
     COMPUTE_MODULES_ADAPTER_MANAGER.update_job_id(job_id=job_id)
     internal_logger.info(INFO_STR)
@@ -76,7 +78,7 @@ def test_initial_log_format(
     parsed_out = list(filter(lambda x: x, captured.err.split("\n")))
     assert len(parsed_out) == 3
     for log in parsed_out:
-        assert format_log_context(pid=2, job_id=job_id) in log
+        assert format_log_context(pid=PROCESS_ID, job_id=job_id) in log
     # Test clearing now
     COMPUTE_MODULES_ADAPTER_MANAGER.update_job_id(job_id="")
     internal_logger.info(INFO_STR)
@@ -86,4 +88,4 @@ def test_initial_log_format(
     parsed_out = list(filter(lambda x: x, captured.err.split("\n")))
     assert len(parsed_out) == 3
     for log in parsed_out:
-        assert format_log_context(pid=2, job_id="") in log
+        assert format_log_context(pid=PROCESS_ID, job_id="") in log


### PR DESCRIPTION
This is a superset of #16 

## Before this PR
See [slack thread](https://palantir.slack.com/archives/C04T0Q9V7TN/p1730190464823899)

BLUF: the current design of this library has all processes polling for & executing jobs independently of each other. In addition, every request used a different connection. This caused memory issues because the runtime had to handle TLS handshake, which produced some memory overhead for each.

## After this PR
Re-use connections within the CM and only poll for jobs from the parent process - delegating any jobs received to a worker pool. 

==COMMIT_MSG==
Performance improvements: process pooling; reusing connections
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

## Are Docs needed?
No
