### PR TITLE
Send OAuth scopes as space-separated string

### DIFF
--- a/changelog/@unreleased/pr-21.v2.yml
+++ b/changelog/@unreleased/pr-21.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Send OAuth scopes as space-separated string
+  links:
+  - https://github.com/palantir/python-compute-module/pull/21

--- a/compute_modules/auth/third_party.py
+++ b/compute_modules/auth/third_party.py
@@ -35,7 +35,7 @@ def oauth(hostname: str, scope: List[str]) -> Any:
                 "grant_type": "client_credentials",
                 "client_id": CLIENT_ID,
                 "client_secret": CLIENT_SECRET,
-                "scope": scope,
+                "scope": " ".join(scope),
             }
         )
         headers = {


### PR DESCRIPTION
## Before this PR
Per [documentation](https://www.palantir.com/docs/foundry/platform-security-third-party/writing-oauth2-clients#oauth2-api-reference), OAuth scopes should be sent as a space-separated string. Our current implementation is incorrectly URL-encoding the list representation directly.

## After this PR
Concatenate OAuth scopes as a space-separated string.

==COMMIT_MSG==
Send OAuth scopes as space-separated string
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

## Are Docs needed?
<!-- Please indicate whether documentation is needed for this PR. -->
