### PR TITLE
[Connectivity] Support mounted source config

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@
 > This SDK is incubating and subject to change.
 
 
-An open-source python library for compute modules for performing tasks like service discovery, getting a token, external source credentials, etc
+An open-source python library for compute modules for performing tasks like service discovery, getting a token, accessing external sources, etc.
 
 
 
 ## Functions Mode
-Sources can be used to store secrets for use within a Compute Module, they prevent you from having to put secrets in your container or in plaintext in the job specification. 
-Retrieving a source credential using this library is simple, if you are in Functions Mode they are passed to the context
+
+Sources can be used in Compute Modules to access secrets or the source configuration itself.
+Retrieving information about a source using this library is simple, if you are in Functions Mode both secrets and configurations are passed in the context.
 
 ### Basic usage
 
@@ -29,8 +30,13 @@ def add(context, event) -> int:
     return event["x"] + event["y"]
 
 @function
-def get_sources(context, event) -> List[str]:
-    return context["sources"].keys()
+def get_sources(context, event) -> dict:
+    source_secrets = context["sources"]
+    source_configs = context["source_configs"]
+    return {
+        "secrets": source_secrets
+        "configs": source_configs
+    }
 ```
 
 
@@ -251,17 +257,20 @@ If left un-annotated, the `context` param will be a `dict`.
 
 
 ## Pipelines Mode
-### Retrieving source credentials
+### Retrieving source information
 
-Sources allow you to store secrets securely for use within a Compute Module, eliminating the need to include secrets in your container or in plaintext within the job specification. Retrieving a source credential using this library is straightforward:
+Sources can be used in Compute Modules to access secrets or the source configuration itself.
+Retrieving information about a source using this library is straightforward:
 ```python
-from compute_modules.sources import get_sources, get_source_secret
+from compute_modules.sources import get_sources, get_source_secret, get_source_configurations, get_source_config
 
-# retrive a dict with all sources
-sources = get_sources()
+# retrieve a dict with all sources
+all_source_creds = get_sources()
+all_source_configs = get_source_configurations()
 
-# retrive the credentials of a specific source 
+# retrieve the credentials of a specific source 
 my_creds = get_source_secret("mySourceApiName", "MyCredential")
+my_config = get_source_config("mySourceApiName")
 
 ```
 
@@ -273,10 +282,10 @@ The SDK offers a convenient method for retrieving information on the resources c
 from compute_modules.resources import PipelineResource, get_pipeline_resources
 
 resources: dict[str, PipelineResource] = get_pipeline_resources()
-print(f"My reource's rid is: {resources['your-alias-name'].rid}")
+print(f"My resource's rid is: {resources['your-alias-name'].rid}")
 ```
 
-### Retriving pipeline token
+### Retrieving pipeline token
 
 To obtain an auth token for interacting with Foundry resources in Pipeline mode use the following function:
 

--- a/changelog/@unreleased/pr-28.v2.yml
+++ b/changelog/@unreleased/pr-28.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: '[Connectivity] Support mounted source config'
+  links:
+  - https://github.com/palantir/python-compute-module/pull/28

--- a/compute_modules/context/context.py
+++ b/compute_modules/context/context.py
@@ -20,9 +20,7 @@ from ..sources import get_source_configurations, get_sources
 
 
 def get_extra_context_parameters() -> Dict[str, Any]:
-    source_configs = {key: value.source_configuration for key, value in get_source_configurations().items()}
-
-    context_parameters: Dict[str, Any] = {"sources": get_sources(), "source_configs": source_configs}
+    context_parameters: Dict[str, Any] = {"sources": get_sources(), "source_configs": get_source_configurations()}
     CLIENT_ID, CLIENT_SECRET = retrieve_third_party_id_and_creds()
 
     if CLIENT_ID and CLIENT_SECRET:

--- a/compute_modules/context/context.py
+++ b/compute_modules/context/context.py
@@ -16,11 +16,13 @@
 from typing import Any, Dict
 
 from ..auth import retrieve_third_party_id_and_creds
-from ..sources import get_sources
+from ..sources import get_source_configurations, get_sources
 
 
 def get_extra_context_parameters() -> Dict[str, Any]:
-    context_parameters = {"sources": get_sources()}
+    source_configs = {key: value.source_configuration for key, value in get_source_configurations().items()}
+
+    context_parameters: Dict[str, Any] = {"sources": get_sources(), "source_configs": source_configs}
     CLIENT_ID, CLIENT_SECRET = retrieve_third_party_id_and_creds()
 
     if CLIENT_ID and CLIENT_SECRET:

--- a/compute_modules/sources.py
+++ b/compute_modules/sources.py
@@ -15,27 +15,44 @@
 
 import json
 import os
+from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
 
-
-class MountedHttpConnectionConfig(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
+@dataclass
+class MountedHttpConnectionConfig:
     url: str
-    auth_headers: dict[str, str] = Field(alias="authHeaders", default_factory=dict)
-    query_parameters: dict[str, str] = Field(alias="queryParameters", default_factory=dict)
+    auth_headers: Dict[str, str] = field(default_factory=dict)
+    query_parameters: Dict[str, str] = field(default_factory=dict)
+
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> "MountedHttpConnectionConfig":
+        return MountedHttpConnectionConfig(
+            url=data["url"], auth_headers=data.get("authHeaders", {}), query_parameters=data.get("queryParameters", {})
+        )
 
 
-class MountedSourceConfig(BaseModel):
-    model_config = ConfigDict(extra="ignore")
+@dataclass
+class MountedSourceConfig:
+    secrets: Dict[str, str] = field(default_factory=dict)
+    http_connection_config: Optional[MountedHttpConnectionConfig] = None
+    proxy_token: Optional[str] = None
+    source_configuration: Any = None
+    resolved_credentials: Any = None
 
-    secrets: dict[str, str] = Field(alias="secrets", default_factory=dict)
-    proxy_token: Optional[str] = Field(alias="proxyToken", default=None)
-    http_connection_config: MountedHttpConnectionConfig = Field(alias="httpConnectionConfig")
-    source_configuration: Any = Field(alias="sourceConfiguration", default=None)
-    resolved_credentials: Any = Field(alias="resolvedCredentials", default=None)
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> "MountedSourceConfig":
+        http_conn_config_data = data.get("httpConnectionConfig")
+        http_conn_config = (
+            MountedHttpConnectionConfig.from_dict(http_conn_config_data) if http_conn_config_data is not None else None
+        )
+        return MountedSourceConfig(
+            secrets=data.get("secrets", {}),
+            proxy_token=data.get("proxyToken"),
+            http_connection_config=http_conn_config,
+            source_configuration=data.get("sourceConfiguration"),
+            resolved_credentials=data.get("resolvedCredentials"),
+        )
 
 
 _source_credentials = None
@@ -62,11 +79,11 @@ def get_source_configurations() -> Dict[str, Any]:
         configs_path = os.environ.get("SOURCE_CONFIGURATIONS_PATH")
         if configs_path:
             with open(configs_path, "r", encoding="utf-8") as fr:
-                source_configs: Dict[str, MountedSourceConfig] = {
-                    key: MountedSourceConfig.model_validate(value) for key, value in json.load(fr).items()
+                raw_configs = json.load(fr)
+            if isinstance(raw_configs, dict):
+                _source_configurations = {
+                    key: MountedSourceConfig.from_dict(value) for key, value in raw_configs.items()
                 }
-            if isinstance(source_configs, dict):
-                _source_configurations = source_configs
             else:
                 raise ValueError("The JSON content is not a dictionary")
     configs = _source_configurations if _source_configurations is not None else {}

--- a/compute_modules/sources.py
+++ b/compute_modules/sources.py
@@ -15,12 +15,34 @@
 
 import json
 import os
-from typing import Any
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class MountedHttpConnectionConfig(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    url: str
+    auth_headers: dict[str, str] = Field(alias="authHeaders", default_factory=dict)
+    query_parameters: dict[str, str] = Field(alias="queryParameters", default_factory=dict)
+
+
+class MountedSourceConfig(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    secrets: dict[str, str] = Field(alias="secrets", default_factory=dict)
+    proxy_token: Optional[str] = Field(alias="proxyToken", default=None)
+    http_connection_config: MountedHttpConnectionConfig = Field(alias="httpConnectionConfig")
+    source_configuration: Any = Field(alias="sourceConfiguration", default=None)
+    resolved_credentials: Any = Field(alias="resolvedCredentials", default=None)
+
 
 _source_credentials = None
+_source_configurations = None
 
 
-def get_sources() -> Any:
+def get_sources() -> Dict[str, Dict[str, str]]:
     global _source_credentials
     if _source_credentials is None:
         creds_path = os.environ.get("SOURCE_CREDENTIALS")
@@ -31,9 +53,30 @@ def get_sources() -> Any:
                 _source_credentials = data
             else:
                 raise ValueError("The JSON content is not a dictionary")
-    return _source_credentials
+    return _source_credentials if _source_credentials is not None else {}
+
+
+def get_source_configurations() -> Dict[str, MountedSourceConfig]:
+    global _source_configurations
+    if _source_configurations is None:
+        configs_path = os.environ.get("SOURCE_CONFIGURATIONS_PATH")
+        if configs_path:
+            with open(configs_path, "r", encoding="utf-8") as fr:
+                source_configs: Dict[str, MountedSourceConfig] = {
+                    key: MountedSourceConfig.model_validate(value) for key, value in json.load(fr).items()
+                }
+            if isinstance(source_configs, dict):
+                _source_configurations = source_configs
+            else:
+                raise ValueError("The JSON content is not a dictionary")
+    return _source_configurations if _source_configurations is not None else {}
 
 
 def get_source_secret(source_api_name: str, credential_name: str) -> Any:
     source_credentials = get_sources()
     return source_credentials.get(source_api_name, {}).get(credential_name)
+
+
+def get_source_config(source_api_name: str) -> Any:
+    source_config = get_source_configurations().get(source_api_name)
+    return source_config.source_configuration if source_config else None

--- a/compute_modules/sources.py
+++ b/compute_modules/sources.py
@@ -56,7 +56,7 @@ def get_sources() -> Dict[str, Dict[str, str]]:
     return _source_credentials if _source_credentials is not None else {}
 
 
-def get_source_configurations() -> Dict[str, MountedSourceConfig]:
+def get_source_configurations() -> Dict[str, Any]:
     global _source_configurations
     if _source_configurations is None:
         configs_path = os.environ.get("SOURCE_CONFIGURATIONS_PATH")
@@ -69,7 +69,8 @@ def get_source_configurations() -> Dict[str, MountedSourceConfig]:
                 _source_configurations = source_configs
             else:
                 raise ValueError("The JSON content is not a dictionary")
-    return _source_configurations if _source_configurations is not None else {}
+    configs = _source_configurations if _source_configurations is not None else {}
+    return {key: value.source_configuration for key, value in configs.items()}
 
 
 def get_source_secret(source_api_name: str, credential_name: str) -> Any:
@@ -78,5 +79,4 @@ def get_source_secret(source_api_name: str, credential_name: str) -> Any:
 
 
 def get_source_config(source_api_name: str) -> Any:
-    source_config = get_source_configurations().get(source_api_name)
-    return source_config.source_configuration if source_config else None
+    return get_source_configurations().get(source_api_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ pytest = "8.0.0"
 pytest-html = "4.1.1"
 poethepoet = "^0.29.0"
 types-requests = "^2.32.0.20241016"
-pydantic = "^2.10.6"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ pytest = "8.0.0"
 pytest-html = "4.1.1"
 poethepoet = "^0.29.0"
 types-requests = "^2.32.0.20241016"
+pydantic = "^2.10.6"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Before this PR
- Currently we mount source information onto the container with no first class way of retrieving them

## After this PR
- Added support for bulk or singular retrieval of source configs. More specifically the public API definition of the source config. See [here](https://github.com/palantir/foundry-platform-python/blob/develop/foundry/v2/connectivity/models/_connection_configuration.py) for reference