### PR TITLE
Fix missing kwargs in query context

### DIFF
--- a/changelog/@unreleased/pr-29.v2.yml
+++ b/changelog/@unreleased/pr-29.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix missing kwargs in query context
+  links:
+  - https://github.com/palantir/python-compute-module/pull/29

--- a/compute_modules/context/types.py
+++ b/compute_modules/context/types.py
@@ -45,7 +45,10 @@ class QueryContext:
     """
 
     sources: Optional[Dict[str, Any]] = None
-    """dict containing the metadata of any sources configured for this compute module."""
+    """dict containing the secrets of any sources configured for this compute module."""
+
+    source_configs: Optional[Dict[str, Any]] = None
+    """dict containing the configuration of any sources configured for this compute module."""
 
     userId: Optional[str] = None
     """The unique identifier for the user who initiated the job"""


### PR DESCRIPTION
## Before this PR
- User compute modules failing as the `QueryContext` does not reflect the newly populated query_context here: https://github.com/palantir/python-compute-module/pull/28

## After this PR
- Add support

## FLUP
- This is a dangerous way to initialize the context and there is no test to catch this. We should FLUP to have an initialization method which handles unknown fields or have a test that checks for this
