### PR TITLE
[Connectivity] Source interface in Compute Modules Lib

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - image: cimg/python:<< parameters.python_version >>
     steps:
       - checkout
-      - run: poetry install
+      - run: poetry install --extras sources
       - run: poetry run poe test
 
   mypy:
@@ -24,7 +24,7 @@ jobs:
       - image: cimg/python:3.12
     steps:
       - checkout
-      - run: poetry install
+      - run: poetry install --extras sources
       - run: poetry run poe check_mypy
 
   check_format:
@@ -32,7 +32,7 @@ jobs:
       - image: cimg/python:3.12
     steps:
       - checkout
-      - run: poetry install
+      - run: poetry install --extras sources
       - run: poetry run poe check_format
 
   check_license:
@@ -40,7 +40,7 @@ jobs:
       - image: cimg/python:3.12
     steps:
       - checkout
-      - run: poetry install
+      - run: poetry install --extras sources
       - run: poetry run poe check_license
 
   circle-all:
@@ -54,7 +54,7 @@ jobs:
       - image: cimg/python:3.12
     steps:
       - checkout
-      - run: poetry install
+      - run: poetry install --extras sources
       - run: poetry run poe set_version
       - run: poetry publish -v -u $PYPI_USERNAME -p $PYPI_PASSWORD --build
 

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -14,7 +14,7 @@
 This command will install all deps specified in `pyproject.toml` and make the scripts specified in `pyproject.toml` available in your python environment.
 
 ```sh
-poetry install
+poetry install --extras sources
 ```
 
 ### Run tests

--- a/README.md
+++ b/README.md
@@ -12,10 +12,23 @@ An open-source python library for compute modules for performing tasks like serv
 
 
 
+## Installation
+
+Install the package via `pip`:
+
+```bash
+pip install foundry-compute-modules
+```
+
+For [Foundry Sources](#sources-in-compute-modules) support, include the sources optional dependency:
+```bash
+pip install foundry-compute-modules[sources]
+```
+
+
 ## Functions Mode
 
-Sources can be used in Compute Modules to access secrets or the source configuration itself.
-Retrieving information about a source using this library is simple, if you are in Functions Mode both secrets and configurations are passed in the context.
+> Looking for documentation on Foundry Sources? Please refer to the [Sources in Compute Modules](#sources-in-compute-modules) section for more information.
 
 ### Basic usage
 
@@ -28,6 +41,12 @@ from compute_modules.annotations import function
 @function
 def add(context, event) -> int:
     return event["x"] + event["y"]
+```
+
+#### (Deprecated) Retrieving source information
+```python
+# functions/source_example.py
+from compute_modules.annotations import function
 
 @function
 def get_sources(context, event) -> dict:
@@ -257,10 +276,11 @@ If left un-annotated, the `context` param will be a `dict`.
 
 
 ## Pipelines Mode
-### Retrieving source information
+### (Deprecated) Retrieving source information
 
-Sources can be used in Compute Modules to access secrets or the source configuration itself.
-Retrieving information about a source using this library is straightforward:
+Please use the recommended approach for interacting with Sources as detailed in the [Sources in Compute Modules section](#sources-in-compute-modules)
+
+You can still access Source secrets and configuration using the deprecated API with the following snippet:
 ```python
 from compute_modules.sources import get_sources, get_source_secret, get_source_configurations, get_source_config
 
@@ -269,8 +289,10 @@ all_source_creds = get_sources()
 all_source_configs = get_source_configurations()
 
 # retrieve the credentials of a specific source 
-my_creds = get_source_secret("mySourceApiName", "MyCredential")
-my_config = get_source_config("mySourceApiName")
+my_creds = get_source_secret("<SOURCE_API_NAME>", "MyCredential")
+
+# retrieve the source configuration
+my_config = get_source_config("<SOURCE_API_NAME>")
 
 ```
 
@@ -296,6 +318,25 @@ import requests
 pipeline_token = retrieve_pipeline_token()
 requests.post(..., headers={"Authorization": f"Bearer {pipeline_token}")
 ```
+
+## Sources in Compute Modules
+
+For every Foundry Source imported into your Compute Module (CM), a pre-configured client is generated based on the Source's provided configuration. Before using Sources in Compute Modules please follow the [Installation guide](#installation) to make sure you have the correct dependencies installed.
+
+> For more information about the functionality available on the client, please visit the [External Systems library documentation](https://github.com/palantir/external-systems/)
+
+### Example
+
+For Compute Modules running in either Pipelines or Functions mode, the Source can be retrieved using the following snippet:
+
+```python
+from compute_modules.sources_v2 import get_source
+from external_systems.sources import Source
+
+source: Source = get_source("<SOURCE_API_NAME>")
+```
+
+**NOTE:** Connections to on-premise external systems require additional configuration. Please contact your Palantir representative for more information.
 
 
 ## Application's permissions/ Third Party App

--- a/changelog/@unreleased/pr-32.v2.yml
+++ b/changelog/@unreleased/pr-32.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: '[Connectivity] Source interface in Compute Modules Lib'
+  links:
+  - https://github.com/palantir/python-compute-module/pull/32

--- a/compute_modules/context/context.py
+++ b/compute_modules/context/context.py
@@ -16,11 +16,17 @@
 from typing import Any, Dict
 
 from ..auth import retrieve_third_party_id_and_creds
-from ..sources import get_source_configurations, get_sources
+from ..sources_v2._back_compat import get_mounted_source_secrets, get_mounted_sources
 
 
 def get_extra_context_parameters() -> Dict[str, Any]:
-    context_parameters: Dict[str, Any] = {"sources": get_sources(), "source_configs": get_source_configurations()}
+    formatted_source_configurations = {key: value.source_configuration for key, value in get_mounted_sources().items()}
+
+    context_parameters: Dict[str, Any] = {
+        "sources": get_mounted_source_secrets(),
+        "source_configs": formatted_source_configurations,
+    }
+
     CLIENT_ID, CLIENT_SECRET = retrieve_third_party_id_and_creds()
 
     if CLIENT_ID and CLIENT_SECRET:

--- a/compute_modules/sources/__init__.py
+++ b/compute_modules/sources/__init__.py
@@ -1,0 +1,39 @@
+#  Copyright 2025 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from ._sources import (
+    SOURCE_CONFIGURATIONS_PATH,
+    SOURCE_CREDENTIALS_PATH,
+    MountedHttpConnectionConfig,
+    MountedSourceConfig,
+    _source_configurations,
+    _source_credentials,
+    get_source_config,
+    get_source_configurations,
+    get_source_secret,
+    get_sources,
+)
+
+__all__ = [
+    "SOURCE_CONFIGURATIONS_PATH",
+    "SOURCE_CREDENTIALS_PATH",
+    "MountedHttpConnectionConfig",
+    "MountedSourceConfig",
+    "_source_configurations",
+    "_source_credentials",
+    "get_source_config",
+    "get_source_configurations",
+    "get_source_secret",
+    "get_sources",
+]

--- a/compute_modules/sources/_sources.py
+++ b/compute_modules/sources/_sources.py
@@ -15,8 +15,17 @@
 
 import json
 import os
+import warnings
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
+
+# Global Mutable State
+_source_credentials = None
+_source_configurations = None
+
+# Env var constants
+SOURCE_CONFIGURATIONS_PATH = "SOURCE_CONFIGURATIONS_PATH"
+SOURCE_CREDENTIALS_PATH = "SOURCE_CREDENTIALS"
 
 
 @dataclass
@@ -55,14 +64,15 @@ class MountedSourceConfig:
         )
 
 
-_source_credentials = None
-_source_configurations = None
-
-
 def get_sources() -> Dict[str, Dict[str, str]]:
+    warnings.warn(
+        "get_sources is deprecated. Use get_source in compute_modules.sources_v2 instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     global _source_credentials
     if _source_credentials is None:
-        creds_path = os.environ.get("SOURCE_CREDENTIALS")
+        creds_path = os.environ.get(SOURCE_CREDENTIALS_PATH)
         if creds_path:
             with open(creds_path, "r", encoding="utf-8") as fr:
                 data = json.load(fr)
@@ -74,9 +84,14 @@ def get_sources() -> Dict[str, Dict[str, str]]:
 
 
 def get_source_configurations() -> Dict[str, Any]:
+    warnings.warn(
+        "get_source_configurations is deprecated. Use get_source in compute_modules.sources_v2 instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     global _source_configurations
     if _source_configurations is None:
-        configs_path = os.environ.get("SOURCE_CONFIGURATIONS_PATH")
+        configs_path = os.environ.get(SOURCE_CONFIGURATIONS_PATH)
         if configs_path:
             with open(configs_path, "r", encoding="utf-8") as fr:
                 raw_configs = json.load(fr)
@@ -91,9 +106,19 @@ def get_source_configurations() -> Dict[str, Any]:
 
 
 def get_source_secret(source_api_name: str, credential_name: str) -> Any:
+    warnings.warn(
+        "get_source_secret is deprecated. Use get_source in compute_modules.sources_v2 instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     source_credentials = get_sources()
     return source_credentials.get(source_api_name, {}).get(credential_name)
 
 
 def get_source_config(source_api_name: str) -> Any:
-    return get_source_configurations().get(source_api_name)
+    warnings.warn(
+        "get_source_config is deprecated. Use get_source in compute_modules.sources_v2 instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return get_source_configurations().get(source_api_name, {})

--- a/compute_modules/sources_v2/__init__.py
+++ b/compute_modules/sources_v2/__init__.py
@@ -1,0 +1,19 @@
+#  Copyright 2025 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from ._sources import get_source
+
+__all__ = [
+    "get_source",
+]

--- a/compute_modules/sources_v2/_api.py
+++ b/compute_modules/sources_v2/_api.py
@@ -1,0 +1,82 @@
+#  Copyright 2025 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+# Env var constants
+SOURCE_CONFIGURATIONS_PATH = "SOURCE_CONFIGURATIONS_PATH"
+SOURCE_CREDENTIALS_PATH = "SOURCE_CREDENTIALS"
+SERVICE_DISCOVERY_PATH = "FOUNDRY_SERVICE_DISCOVERY_V2"
+DEFAULT_CA_BUNDLE = "DEFAULT_CA_PATH"
+
+
+JAVA_OFFSET_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+@dataclass
+class MountedClientCertificate:
+    pem_certificate: str
+    pem_private_key: str
+
+    @staticmethod
+    def from_dict(data: dict[str, Any]) -> "MountedClientCertificate":
+        return MountedClientCertificate(pem_certificate=data["pemCertificate"], pem_private_key=data["pemPrivateKey"])
+
+
+@dataclass
+class MountedHttpConnectionConfig:
+    url: str
+    auth_headers: dict[str, str] = field(default_factory=dict)
+    query_parameters: dict[str, str] = field(default_factory=dict)
+
+    @staticmethod
+    def from_dict(data: dict[str, Any]) -> "MountedHttpConnectionConfig":
+        return MountedHttpConnectionConfig(
+            url=data["url"], auth_headers=data.get("authHeaders", {}), query_parameters=data.get("queryParameters", {})
+        )
+
+
+@dataclass
+class MountedSourceConfig:
+    secrets: dict[str, str] = field(default_factory=dict)
+    http_connection_config: Optional[MountedHttpConnectionConfig] = None
+    proxy_token: Optional[str] = None
+    source_configuration: Any = None
+    resolved_credentials: Any = None
+    client_certificate: Optional[MountedClientCertificate] = None
+    server_certificates: dict[str, str] = field(default_factory=dict)
+
+    @staticmethod
+    def from_dict(data: dict[str, Any]) -> "MountedSourceConfig":
+        http_conn_config_data = data.get("httpConnectionConfig")
+        http_conn_config = (
+            MountedHttpConnectionConfig.from_dict(http_conn_config_data) if http_conn_config_data is not None else None
+        )
+
+        client_certificate_data = data.get("clientCertificate")
+        client_certificate = (
+            MountedClientCertificate.from_dict(client_certificate_data) if client_certificate_data is not None else None
+        )
+
+        return MountedSourceConfig(
+            secrets=data.get("secrets", {}),
+            proxy_token=data.get("proxyToken"),
+            http_connection_config=http_conn_config,
+            source_configuration=data.get("sourceConfiguration"),
+            resolved_credentials=data.get("resolvedCredentials"),
+            client_certificate=client_certificate,
+            server_certificates=data.get("serverCertificates", {}),
+        )

--- a/compute_modules/sources_v2/_back_compat.py
+++ b/compute_modules/sources_v2/_back_compat.py
@@ -1,0 +1,48 @@
+#  Copyright 2025 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import json
+import os
+from functools import cache
+
+from ._api import SOURCE_CONFIGURATIONS_PATH, SOURCE_CREDENTIALS_PATH, MountedSourceConfig
+
+
+@cache
+def get_mounted_source_secrets() -> dict[str, dict[str, str]]:
+    creds_path = os.environ.get(SOURCE_CREDENTIALS_PATH)
+    if not creds_path:
+        return {}
+    data = {}
+    with open(creds_path, "r", encoding="utf-8") as fr:
+        data.update(json.load(fr))
+    if isinstance(data, dict):
+        return data
+    else:
+        raise ValueError("The JSON content is not a dictionary")
+
+
+@cache
+def get_mounted_sources() -> dict[str, MountedSourceConfig]:
+    mounted_sources = {}
+    configs_path = os.environ.get(SOURCE_CONFIGURATIONS_PATH)
+    if configs_path:
+        with open(configs_path, "r", encoding="utf-8") as fr:
+            raw_configs = json.load(fr)
+        if isinstance(raw_configs, dict):
+            mounted_sources = {key: MountedSourceConfig.from_dict(value) for key, value in raw_configs.items()}
+        else:
+            raise ValueError("The JSON content is not a dictionary")
+    return mounted_sources

--- a/compute_modules/sources_v2/_sources.py
+++ b/compute_modules/sources_v2/_sources.py
@@ -1,0 +1,127 @@
+#  Copyright 2025 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+from datetime import datetime
+from functools import cache
+from typing import Any, Optional
+
+from ._api import DEFAULT_CA_BUNDLE, JAVA_OFFSET_DATETIME_FORMAT, SERVICE_DISCOVERY_PATH, MountedSourceConfig
+from ._back_compat import get_mounted_sources
+
+
+def __get_on_prem_proxy_service_uris() -> list[str]:
+    try:
+        import yaml
+    except ImportError:
+        raise ImportError(
+            "the sources extras is not installed. Please install it with `pip install compute-modules[sources]`"
+        )
+
+    with open(os.environ[SERVICE_DISCOVERY_PATH], "r") as f:
+        service_discovery = yaml.safe_load(f)
+        on_prem_proxy_uris: list[str] = service_discovery.get("on_prem_proxy", [])
+        return on_prem_proxy_uris
+
+
+@cache
+def get_source(source_api_name: str):  # type: ignore[no-untyped-def]
+    try:
+        from external_systems.sources import (
+            AwsCredentials,
+            ClientCertificate,
+            HttpsConnectionParameters,
+            Source,
+            SourceCredentials,
+            SourceParameters,
+        )
+    except ImportError:
+        raise ImportError(
+            "the sources extras is not installed. Please install it with `pip install compute-modules[sources]`"
+        )
+
+    def convert_resolved_source_credentials(
+        credentials: Optional[Any],
+    ) -> Optional[SourceCredentials]:
+        if credentials is None:
+            return None
+
+        cloud_credentials = credentials.get("cloudCredentials", None)
+        if cloud_credentials is None:
+            return None
+
+        aws_credentials = cloud_credentials.get("awsCredentials", None)
+        if aws_credentials is None:
+            return None
+
+        session_credentials = aws_credentials.get("sessionCredentials", None)
+        if session_credentials is not None:
+            return AwsCredentials(
+                access_key_id=session_credentials.get("accessKeyId"),
+                secret_access_key=session_credentials.get("secretAccessKey"),
+                session_token=session_credentials.get("sessionToken"),
+                expiration=datetime.strptime(session_credentials.get("expiration"), JAVA_OFFSET_DATETIME_FORMAT),
+            )
+
+        basic_credentials = aws_credentials.get("basicCredentials", None)
+        if basic_credentials is not None:
+            return AwsCredentials(
+                access_key_id=basic_credentials.get("accessKeyId"),
+                secret_access_key=basic_credentials.get("secretAccessKey"),
+            )
+
+        return None
+
+    mounted_source: Optional[MountedSourceConfig] = get_mounted_sources().get(source_api_name, None)
+    if mounted_source is None:
+        raise ValueError(f"Source {source_api_name} not found")
+
+    client_certificate = (
+        ClientCertificate(
+            pem_certificate=mounted_source.client_certificate.pem_certificate,
+            pem_private_key=mounted_source.client_certificate.pem_private_key,
+        )
+        if mounted_source.client_certificate is not None
+        else None
+    )
+
+    source_parameters = SourceParameters(
+        secrets=mounted_source.secrets,
+        proxy_token=mounted_source.proxy_token,
+        https_connections=(
+            {
+                "http_connection": HttpsConnectionParameters(
+                    url=mounted_source.http_connection_config.url,
+                    headers=mounted_source.http_connection_config.auth_headers,
+                    query_params=mounted_source.http_connection_config.query_parameters,
+                )
+            }
+            if mounted_source.http_connection_config is not None
+            else {}
+        ),
+        server_certificates=mounted_source.server_certificates,
+        client_certificate=client_certificate,
+        resolved_source_credentials=convert_resolved_source_credentials(mounted_source.resolved_credentials),
+    )
+
+    on_prem_proxy_service_uris = __get_on_prem_proxy_service_uris()
+
+    return Source(
+        source_parameters=source_parameters,
+        source_configuration=mounted_source.source_configuration,
+        on_prem_proxy_service_uris=on_prem_proxy_service_uris,
+        egress_proxy_service_uris=[],
+        egress_proxy_token=None,
+        ca_bundle_path=os.environ.get(DEFAULT_CA_BUNDLE),
+    )

--- a/compute_modules/sources_v2/_sources.py
+++ b/compute_modules/sources_v2/_sources.py
@@ -23,7 +23,7 @@ from ._back_compat import get_mounted_sources
 
 def __get_on_prem_proxy_service_uris() -> list[str]:
     try:
-        import yaml # type: ignore[import-untyped]
+        import yaml  # type: ignore[import-untyped]
     except ImportError:
         raise ImportError(
             "the sources extras is not installed. Please install it with `pip install compute-modules[sources]`"

--- a/compute_modules/sources_v2/_sources.py
+++ b/compute_modules/sources_v2/_sources.py
@@ -23,7 +23,7 @@ from ._back_compat import get_mounted_sources
 
 def __get_on_prem_proxy_service_uris() -> list[str]:
     try:
-        import yaml
+        import yaml # type: ignore[import-untyped]
     except ImportError:
         raise ImportError(
             "the sources extras is not installed. Please install it with `pip install compute-modules[sources]`"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,12 @@ packages = [{ include = "compute_modules" }]
 [tool.poetry.dependencies]
 python = "^3.9"
 requests = "^2.32.3"
+external-systems = { version = "^0.3.0", optional = true }
+pyyaml = { version = "^6.0.1", optional = true }
+
+
+[tool.poetry.extras]
+sources = ["external-systems", "pyyaml"]
 
 
 [tool.poetry.group.dev.dependencies]
@@ -51,9 +57,7 @@ line_length = 120
 [tool.pytest.ini_options]
 addopts = "--junitxml=./build/pytest-results/pytest-results.xml --html=./build/pytest-results/pytest-results.html"
 cache_dir = "build/.pytest_cache"
-testpaths = [
-    "tests",
-]
+testpaths = ["tests"]
 
 [tool.ruff]
 line-length = 120

--- a/tests/sources_v2/test_sources.py
+++ b/tests/sources_v2/test_sources.py
@@ -1,0 +1,317 @@
+#  Copyright 2025 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import pytest
+from external_systems.sources import AwsCredentials, Source
+
+from compute_modules.sources_v2 import get_source
+from compute_modules.sources_v2._api import (
+    JAVA_OFFSET_DATETIME_FORMAT,
+    SERVICE_DISCOVERY_PATH,
+    SOURCE_CONFIGURATIONS_PATH,
+    MountedHttpConnectionConfig,
+    MountedSourceConfig,
+)
+from compute_modules.sources_v2._back_compat import get_mounted_sources
+
+
+@pytest.fixture
+def mock_source_config_file(tmp_path: Path) -> Path:
+    config_file = tmp_path / "source_config.json"
+    return config_file
+
+
+@pytest.fixture
+def mock_service_discovery_file(tmp_path: Path) -> Path:
+    service_file = tmp_path / "service_discovery.json"
+    service_file.write_text(json.dumps({"on_prem_proxy": ["https://proxy1.example.com", "https://proxy2.example.com"]}))
+    return service_file
+
+
+@pytest.fixture(autouse=True)
+def clear_cache() -> Any:
+    yield
+    get_source.cache_clear()
+    get_mounted_sources.cache_clear()
+
+
+def test_get_source_with_http_connection(mock_source_config_file: Path, mock_service_discovery_file: Path) -> None:
+    source_config = {
+        "test_source": {
+            "secrets": {"SECRET_KEY": "secret_value"},
+            "httpConnectionConfig": {
+                "url": "https://example.com",
+                "authHeaders": {"Authorization": "Bearer token"},
+                "queryParameters": {"param": "value"},
+            },
+            "proxyToken": "proxy_token_123",
+            "sourceConfiguration": {"type": "test_type"},
+            "resolvedCredentials": {"cloudCredentials": None},
+        }
+    }
+
+    mock_source_config_file.write_text(json.dumps(source_config))
+
+    with mock.patch.dict(
+        os.environ,
+        {
+            SOURCE_CONFIGURATIONS_PATH: str(mock_source_config_file),
+            SERVICE_DISCOVERY_PATH: str(mock_service_discovery_file),
+        },
+    ):
+        source = get_source("test_source")
+
+        assert isinstance(source, Source)
+        assert source.get_secret("SECRET_KEY") == "secret_value"
+        https_conn = source.get_https_connection()
+        assert https_conn.url == "https://example.com"
+        assert https_conn.headers == {"Authorization": "Bearer token"}
+        assert https_conn.query_params == {"param": "value"}
+        assert source.source_configuration == {"type": "test_type"}
+        assert source.get_https_proxy_uri() in [
+            "https://user:proxy_token_123@proxy1.example.com",
+            "https://user:proxy_token_123@proxy2.example.com",
+        ]
+
+
+def test_get_source_without_http_connection(mock_source_config_file: Path, mock_service_discovery_file: Path) -> None:
+    source_config = {
+        "test_source": {
+            "secrets": {"SECRET_KEY": "secret_value"},
+            "proxyToken": "proxy_token_123",
+            "sourceConfiguration": {"type": "test_type"},
+            "resolvedCredentials": {"cloudCredentials": None},
+        }
+    }
+
+    mock_source_config_file.write_text(json.dumps(source_config))
+
+    with mock.patch.dict(
+        os.environ,
+        {
+            SOURCE_CONFIGURATIONS_PATH: str(mock_source_config_file),
+            SERVICE_DISCOVERY_PATH: str(mock_service_discovery_file),
+        },
+    ):
+        source = get_source("test_source")
+        assert isinstance(source, Source)
+        assert source.get_secret("SECRET_KEY") == "secret_value"
+        assert source.get_https_proxy_uri() in [
+            "https://user:proxy_token_123@proxy1.example.com",
+            "https://user:proxy_token_123@proxy2.example.com",
+        ]
+        with pytest.raises(ValueError):
+            source.get_https_connection()
+
+
+def test_get_source_with_aws_session_credentials(
+    mock_source_config_file: Path, mock_service_discovery_file: Path
+) -> None:
+    # Create a source config with session credentials directly in the JSON
+    source_config = {
+        "test_source": {
+            "secrets": {},
+            "sourceConfiguration": {"type": "s3"},
+            "resolvedCredentials": {
+                "cloudCredentials": {
+                    "awsCredentials": {
+                        "sessionCredentials": {
+                            "accessKeyId": "ACCESS_KEY",
+                            "secretAccessKey": "SECRET_KEY",
+                            "sessionToken": "SESSION_TOKEN",
+                            "expiration": "2023-01-01T00:00:00Z",
+                        }
+                    }
+                }
+            },
+        }
+    }
+
+    mock_source_config_file.write_text(json.dumps(source_config))
+
+    with mock.patch.dict(
+        os.environ,
+        {
+            SOURCE_CONFIGURATIONS_PATH: str(mock_source_config_file),
+            SERVICE_DISCOVERY_PATH: str(mock_service_discovery_file),
+        },
+    ):
+        source = get_source("test_source")
+        assert isinstance(source, Source)
+        assert source.get_aws_credentials().get() == AwsCredentials(
+            access_key_id="ACCESS_KEY",
+            secret_access_key="SECRET_KEY",
+            session_token="SESSION_TOKEN",
+            expiration=datetime.strptime("2023-01-01T00:00:00Z", JAVA_OFFSET_DATETIME_FORMAT),
+        )
+
+
+def test_get_source_with_aws_basic_credentials(
+    mock_source_config_file: Path, mock_service_discovery_file: Path
+) -> None:
+    # Create a source config with basic credentials directly in the JSON
+    source_config = {
+        "test_source": {
+            "secrets": {},
+            "sourceConfiguration": {"type": "s3"},
+            "resolvedCredentials": {
+                "cloudCredentials": {
+                    "awsCredentials": {
+                        "basicCredentials": {"accessKeyId": "ACCESS_KEY", "secretAccessKey": "SECRET_KEY"}
+                    }
+                }
+            },
+        }
+    }
+
+    mock_source_config_file.write_text(json.dumps(source_config))
+
+    with mock.patch.dict(
+        os.environ,
+        {
+            SOURCE_CONFIGURATIONS_PATH: str(mock_source_config_file),
+            SERVICE_DISCOVERY_PATH: str(mock_service_discovery_file),
+        },
+    ):
+        source = get_source("test_source")
+        assert isinstance(source, Source)
+        assert source.get_aws_credentials().get() == AwsCredentials(
+            access_key_id="ACCESS_KEY",
+            secret_access_key="SECRET_KEY",
+        )
+
+
+def test_get_source_not_found(mock_source_config_file: Path, mock_service_discovery_file: Path) -> None:
+    source_config = {"existing_source": {"secrets": {}, "sourceConfiguration": {"type": "test_type"}}}
+
+    mock_source_config_file.write_text(json.dumps(source_config))
+
+    with mock.patch.dict(
+        os.environ,
+        {
+            SOURCE_CONFIGURATIONS_PATH: str(mock_source_config_file),
+            SERVICE_DISCOVERY_PATH: str(mock_service_discovery_file),
+        },
+    ):
+        with pytest.raises(ValueError, match="Source nonexistent_source not found"):
+            get_source("nonexistent_source")
+
+
+def test_get_source_invalid_config_format(mock_source_config_file: Path, mock_service_discovery_file: Path) -> None:
+    source_config = ["test_source", "another_source"]
+
+    mock_source_config_file.write_text(json.dumps(source_config))
+
+    with mock.patch.dict(
+        os.environ,
+        {
+            SOURCE_CONFIGURATIONS_PATH: str(mock_source_config_file),
+            SERVICE_DISCOVERY_PATH: str(mock_service_discovery_file),
+        },
+    ):
+        with pytest.raises(ValueError, match="The JSON content is not a dictionary"):
+            get_source("test_source")
+
+
+def test_get_source_missing_config_file(mock_service_discovery_file: Path) -> None:
+    with mock.patch.dict(
+        os.environ,
+        {
+            SOURCE_CONFIGURATIONS_PATH: "/nonexistent/path/config.json",
+            SERVICE_DISCOVERY_PATH: str(mock_service_discovery_file),
+        },
+    ):
+        with pytest.raises(FileNotFoundError):
+            get_source("test_source")
+
+
+def test_mounted_http_connection_config_from_dict_full() -> None:
+    data = {
+        "url": "https://example.com",
+        "authHeaders": {"Authorization": "Bearer token"},
+        "queryParameters": {"param": "value"},
+    }
+
+    config = MountedHttpConnectionConfig.from_dict(data)
+
+    assert config.url == "https://example.com"
+    assert config.auth_headers == {"Authorization": "Bearer token"}
+    assert config.query_parameters == {"param": "value"}
+
+
+def test_mounted_http_connection_config_from_dict_minimal() -> None:
+    data = {"url": "https://example.com"}
+
+    config = MountedHttpConnectionConfig.from_dict(data)
+
+    assert config.url == "https://example.com"
+    assert config.auth_headers == {}
+    assert config.query_parameters == {}
+
+
+def test_mounted_source_config_from_dict_full() -> None:
+    data = {
+        "secrets": {"key": "value"},
+        "httpConnectionConfig": {
+            "url": "https://example.com",
+            "authHeaders": {"Authorization": "Bearer token"},
+            "queryParameters": {"param": "value"},
+        },
+        "proxyToken": "proxy_token_123",
+        "sourceConfiguration": {"type": "test_type"},
+        "resolvedCredentials": {"data": "value"},
+    }
+
+    config = MountedSourceConfig.from_dict(data)
+
+    assert config.secrets == {"key": "value"}
+    assert config.proxy_token == "proxy_token_123"
+    assert isinstance(config.http_connection_config, MountedHttpConnectionConfig)
+    assert config.http_connection_config.url == "https://example.com"
+    assert config.source_configuration == {"type": "test_type"}
+    assert config.resolved_credentials == {"data": "value"}
+
+
+def test_mounted_source_config_from_dict_minimal() -> None:
+    data: dict[str, Any] = {}
+
+    config = MountedSourceConfig.from_dict(data)
+
+    assert config.secrets == {}
+    assert config.proxy_token is None
+    assert config.http_connection_config is None
+    assert config.source_configuration is None
+    assert config.resolved_credentials is None
+
+
+def test_mounted_source_config_from_dict_without_http_connection() -> None:
+    data = {
+        "secrets": {"key": "value"},
+        "proxyToken": "proxy_token_123",
+        "sourceConfiguration": {"type": "test_type"},
+    }
+
+    config = MountedSourceConfig.from_dict(data)
+
+    assert config.secrets == {"key": "value"}
+    assert config.proxy_token == "proxy_token_123"
+    assert config.http_connection_config is None
+    assert config.source_configuration == {"type": "test_type"}


### PR DESCRIPTION
## Before this PR
We recently open sourced the [external-systems lib](https://github.com/palantir/external-systems/) to unify the Foundry Source experience in and outside the platform

## After this PR
- Deprecated the V1 implementation of sources in compute modules
- Updated the function context parameter to use the new API/Types
- Introduce `get_source` which returns a pre-configured source client (see linked lib for details)
- Update documentation where necessary

## E2E Testing on Dev Stack
- [x] All previous public functionality with and without the `[sources]` extra installed
	- [x] Function context param (secrets + configs) (also with and without the extra)
- [x] Source interface in CMs
	- [x] REST connections (direct + on-prem)
	- [x] Client certificate source
	- [x] MTLS source
	- [x] AWS session creds
	- [x] TCP Socket (agent proxy)
	- [x] Source configuration (S3, Snowflake, Rest)