### PR TITLE
Allow timestamps to be in higher precision than seconds

### DIFF
--- a/changelog/@unreleased/pr-38.v2.yml
+++ b/changelog/@unreleased/pr-38.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Timestamps can now be in the format with fractional seconds through
+    Python datetime as many timestamps are.
+  links:
+  - https://github.com/palantir/python-compute-module/pull/38

--- a/compute_modules/function_registry/datetime_conversion_util.py
+++ b/compute_modules/function_registry/datetime_conversion_util.py
@@ -25,7 +25,8 @@ class DatetimeConversionUtil:
         obj = datetime_obj.astimezone(timezone.utc)
         # Format as ISO 8601 string with 'Z' suffix
         return obj.strftime(
-            DatetimeConversionUtil.DATETIME_FORMAT_HIGHER_PRECISION_STRING if obj.microsecond > 0
+            DatetimeConversionUtil.DATETIME_FORMAT_HIGHER_PRECISION_STRING
+            if obj.microsecond > 0
             else DatetimeConversionUtil.DATETIME_FORMAT_STRING
         )
 

--- a/compute_modules/function_registry/datetime_conversion_util.py
+++ b/compute_modules/function_registry/datetime_conversion_util.py
@@ -18,13 +18,20 @@ from datetime import datetime, timezone
 
 class DatetimeConversionUtil:
     DATETIME_FORMAT_STRING = "%Y-%m-%dT%H:%M:%SZ"
+    DATETIME_FORMAT_HIGHER_PRECISION_STRING = "%Y-%m-%dT%H:%M:%S.%fZ"
 
     @staticmethod
     def datetime_to_string(datetime_obj: datetime) -> str:
         obj = datetime_obj.astimezone(timezone.utc)
         # Format as ISO 8601 string with 'Z' suffix
-        return obj.strftime(DatetimeConversionUtil.DATETIME_FORMAT_STRING)
+        return obj.strftime(
+            DatetimeConversionUtil.DATETIME_FORMAT_HIGHER_PRECISION_STRING if obj.microsecond > 0
+            else DatetimeConversionUtil.DATETIME_FORMAT_STRING
+        )
 
     @staticmethod
     def string_to_datetime(datetime_string: str) -> datetime:
-        return datetime.strptime(datetime_string, DatetimeConversionUtil.DATETIME_FORMAT_STRING)
+        try:
+            return datetime.strptime(datetime_string, DatetimeConversionUtil.DATETIME_FORMAT_STRING)
+        except ValueError:
+            return datetime.strptime(datetime_string, DatetimeConversionUtil.DATETIME_FORMAT_HIGHER_PRECISION_STRING)


### PR DESCRIPTION
## Before this PR
Timestamps could only be handled at the precision of seconds

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==

Timestamps can now be in the format with fractional seconds through Python datetime as many timestamps are.

==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

## Are Docs needed?
<!-- Please indicate whether documentation is needed for this PR. -->
