### PR TITLE
handle failed result post with error post

### DIFF
--- a/changelog/@unreleased/pr-39.v2.yml
+++ b/changelog/@unreleased/pr-39.v2.yml
@@ -1,5 +1,6 @@
 type: fix
 fix:
-  description: handle failed result post with error post
+  description: 'After this fix: If the job posting fails 5 times (e.g. result too
+    large) then the client tries 5 more times to post just a simple error message.'
   links:
   - https://github.com/palantir/python-compute-module/pull/39

--- a/changelog/@unreleased/pr-39.v2.yml
+++ b/changelog/@unreleased/pr-39.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: handle failed result post with error post
+  links:
+  - https://github.com/palantir/python-compute-module/pull/39

--- a/compute_modules/client/internal_query_client.py
+++ b/compute_modules/client/internal_query_client.py
@@ -162,9 +162,13 @@ class InternalQueryService:
             self.logger.error(f"Get job request failed, attempting to re-establish connection {str(e)}")
             self.logger.error(traceback.format_exc())
             return None
-        
+
     def report_job_result_failed(self, post_result_url: str, error: str) -> None:
-        body = json.dumps({"error": f"Unable to post job result after {POST_RESULT_MAX_ATTEMPTS} attempts; \n Now attempting to return the error as the result: {error}"}).encode("utf-8")
+        body = json.dumps(
+            {
+                "error": f"Unable to post job result after {POST_RESULT_MAX_ATTEMPTS} attempts; \n Now attempting to return the error as the result: {error}"
+            }
+        ).encode("utf-8")
         for _ in range(POST_ERROR_MAX_ATTEMPTS):
             try:
                 with self.session.request(
@@ -183,8 +187,10 @@ class InternalQueryService:
                         )
             except Exception as e:
                 self.logger.error(f"Failed to report that post result has failed: {str(e)}")
-                
-        raise RuntimeError(f"Unable to post job result after {POST_RESULT_MAX_ATTEMPTS} attempts and unable to report that post result has failed after {POST_ERROR_MAX_ATTEMPTS} attempts")
+
+        raise RuntimeError(
+            f"Unable to post job result after {POST_RESULT_MAX_ATTEMPTS} attempts and unable to report that post result has failed after {POST_ERROR_MAX_ATTEMPTS} attempts"
+        )
 
     def report_job_result(self, job_id: str, body: Any) -> None:
         post_result_path = f"{self.post_result_path}/{job_id}"

--- a/compute_modules/client/internal_query_client.py
+++ b/compute_modules/client/internal_query_client.py
@@ -161,6 +161,29 @@ class InternalQueryService:
             self.logger.error(f"Get job request failed, attempting to re-establish connection {str(e)}")
             self.logger.error(traceback.format_exc())
             return None
+        
+    def report_job_result_failed(self, post_result_url: str, error: str) -> None:
+        body = json.dumps({"error": f"Unable to post job result: {error}"}).encode("utf-8")
+        for _ in range(POST_RESULT_MAX_ATTEMPTS):
+            try:
+                with self.session.request(
+                    method="POST",
+                    url=post_result_url,
+                    headers=self.post_result_headers,
+                    data=body,
+                    verify=self.certPath,
+                ) as response:
+                    if response.status_code == 204:
+                        self.logger.debug("Successfully reported that job result posting has failed")
+                        return
+                    else:
+                        self.logger.error(
+                            f"Failed to post result: {response.status_code} {response.reason} {response.text}"
+                        )
+            except Exception as e:
+                self.logger.error(f"Failed to report that post result has failed: {str(e)}")
+                
+        raise RuntimeError(f"Unable to post job result after {POST_RESULT_MAX_ATTEMPTS} attempts")
 
     def report_job_result(self, job_id: str, body: Any) -> None:
         post_result_path = f"{self.post_result_path}/{job_id}"
@@ -179,17 +202,17 @@ class InternalQueryService:
                         self.logger.debug("Successfully reported job result")
                         return
                     else:
-                        self.logger.error(
-                            f"Failed to post result: {response.status_code} {response.reason} {response.text}"
-                        )
+                        error = f"Failed to post result: {response.status_code} {response.reason} {response.text}"
+                        self.logger.error(error)
             except TypeError as e:
                 self.logger.error(f"Failed to serialize result to json: {str(e)}")
                 self.report_job_result(job_id, json.dumps(self.get_failed_query(e)).encode("utf-8"))
                 return
             except Exception as e:
-                self.logger.error(f"POST of job result failed, attempting to re-establish connection: {str(e)}")
-                self.logger.error(traceback.format_exc())
-        raise RuntimeError(f"Unable to post job result after {POST_RESULT_MAX_ATTEMPTS} attempts")
+                error = f"POST of job result failed, attempting to re-establish connection: {str(e)} \n {traceback.format_exc()}"
+                self.logger.error(error)
+
+        self.report_job_result_failed(post_result_url, error)
 
     def handle_job(self, job: Dict[str, Any]) -> None:
         self.logger.info("handling job")

--- a/compute_modules/client/internal_query_client.py
+++ b/compute_modules/client/internal_query_client.py
@@ -33,6 +33,7 @@ from ..context import get_extra_context_parameters
 from .encoder import CustomJSONEncoder
 
 POST_RESULT_MAX_ATTEMPTS = 5
+POST_ERROR_MAX_ATTEMPTS = 3
 POST_SCHEMAS_MAX_ATTEMPTS = 5
 
 
@@ -163,8 +164,8 @@ class InternalQueryService:
             return None
         
     def report_job_result_failed(self, post_result_url: str, error: str) -> None:
-        body = json.dumps({"error": f"Unable to post job result: {error}"}).encode("utf-8")
-        for _ in range(POST_RESULT_MAX_ATTEMPTS):
+        body = json.dumps({"error": f"Unable to post job result after {POST_RESULT_MAX_ATTEMPTS} attempts; \n Now attempting to return the error as the result: {error}"}).encode("utf-8")
+        for _ in range(POST_ERROR_MAX_ATTEMPTS):
             try:
                 with self.session.request(
                     method="POST",
@@ -183,7 +184,7 @@ class InternalQueryService:
             except Exception as e:
                 self.logger.error(f"Failed to report that post result has failed: {str(e)}")
                 
-        raise RuntimeError(f"Unable to post job result after {POST_RESULT_MAX_ATTEMPTS} attempts")
+        raise RuntimeError(f"Unable to post job result after {POST_RESULT_MAX_ATTEMPTS} attempts and unable to report that post result has failed after {POST_ERROR_MAX_ATTEMPTS} attempts")
 
     def report_job_result(self, job_id: str, body: Any) -> None:
         post_result_path = f"{self.post_result_path}/{job_id}"

--- a/compute_modules/client/internal_query_client.py
+++ b/compute_modules/client/internal_query_client.py
@@ -163,14 +163,14 @@ class InternalQueryService:
             self.logger.error(traceback.format_exc())
             return None
 
-    def report_job_result_failed(self, post_result_url: str, error_body: bytes) -> None:
+    def report_job_result_failed(self, post_result_url: str, error: str) -> None:
         for _ in range(POST_ERROR_MAX_ATTEMPTS):
             try:
                 with self.session.request(
                     method="POST",
                     url=post_result_url,
                     headers=self.post_result_headers,
-                    data=error_body,
+                    data=json.dumps({"error": error}).encode("utf-8"),
                     verify=self.certPath,
                 ) as response:
                     if response.status_code == 204:
@@ -207,17 +207,13 @@ class InternalQueryService:
             except TypeError as e:
                 error = f"Failed to serialize result to json: {self.get_failed_query(e)}"
                 self.logger.error(error)
-                self.report_job_result_failed(post_result_url, json.dumps({"error": error}).encode("utf-8"))
+                self.report_job_result_failed(post_result_url, error)
                 return
             except Exception as e:
                 error = f"POST of job result failed, attempting to re-establish connection: {str(e)} \n {traceback.format_exc()}"
                 self.logger.error(error)
 
-        error = json.dumps(
-            {
-                "error": f"Unable to post job result after {POST_RESULT_MAX_ATTEMPTS} attempts; \n Now attempting to return the error as the result: {error}"
-            }
-        ).encode("utf-8")
+        error = f"Unable to post job result after {POST_RESULT_MAX_ATTEMPTS} attempts; \n Now attempting to return the error as the result: {error}"
         self.logger.debug(error)
         self.report_job_result_failed(post_result_url, error)
 

--- a/compute_modules/client/internal_query_client.py
+++ b/compute_modules/client/internal_query_client.py
@@ -163,19 +163,14 @@ class InternalQueryService:
             self.logger.error(traceback.format_exc())
             return None
 
-    def report_job_result_failed(self, post_result_url: str, error: str) -> None:
-        body = json.dumps(
-            {
-                "error": f"Unable to post job result after {POST_RESULT_MAX_ATTEMPTS} attempts; \n Now attempting to return the error as the result: {error}"
-            }
-        ).encode("utf-8")
+    def report_job_result_failed(self, post_result_url: str, error_body: bytes) -> None:
         for _ in range(POST_ERROR_MAX_ATTEMPTS):
             try:
                 with self.session.request(
                     method="POST",
                     url=post_result_url,
                     headers=self.post_result_headers,
-                    data=body,
+                    data=error_body,
                     verify=self.certPath,
                 ) as response:
                     if response.status_code == 204:
@@ -188,9 +183,7 @@ class InternalQueryService:
             except Exception as e:
                 self.logger.error(f"Failed to report that post result has failed: {str(e)}")
 
-        raise RuntimeError(
-            f"Unable to post job result after {POST_RESULT_MAX_ATTEMPTS} attempts and unable to report that post result has failed after {POST_ERROR_MAX_ATTEMPTS} attempts"
-        )
+        raise RuntimeError(f"Unable to report that post result has failed after {POST_ERROR_MAX_ATTEMPTS} attempts")
 
     def report_job_result(self, job_id: str, body: Any) -> None:
         post_result_path = f"{self.post_result_path}/{job_id}"
@@ -212,13 +205,20 @@ class InternalQueryService:
                         error = f"Failed to post result: {response.status_code} {response.reason} {response.text}"
                         self.logger.error(error)
             except TypeError as e:
-                self.logger.error(f"Failed to serialize result to json: {str(e)}")
-                self.report_job_result(job_id, json.dumps(self.get_failed_query(e)).encode("utf-8"))
+                error = f"Failed to serialize result to json: {self.get_failed_query(e)}"
+                self.logger.error(error)
+                self.report_job_result_failed(post_result_url, json.dumps({"error": error}).encode("utf-8"))
                 return
             except Exception as e:
                 error = f"POST of job result failed, attempting to re-establish connection: {str(e)} \n {traceback.format_exc()}"
                 self.logger.error(error)
 
+        error = json.dumps(
+            {
+                "error": f"Unable to post job result after {POST_RESULT_MAX_ATTEMPTS} attempts; \n Now attempting to return the error as the result: {error}"
+            }
+        ).encode("utf-8")
+        self.logger.debug(error)
         self.report_job_result_failed(post_result_url, error)
 
     def handle_job(self, job: Dict[str, Any]) -> None:

--- a/compute_modules/client/internal_query_client.py
+++ b/compute_modules/client/internal_query_client.py
@@ -214,7 +214,7 @@ class InternalQueryService:
                 self.logger.error(error)
 
         error = f"Unable to post job result after {POST_RESULT_MAX_ATTEMPTS} attempts; \n Now attempting to return the error as the result: {error}"
-        self.logger.debug(error)
+        self.logger.error(error)
         self.report_job_result_failed(post_result_url, error)
 
     def handle_job(self, job: Dict[str, Any]) -> None:


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
If posting the job result fails 5 times an exception gets raised but the forwarder doesn't know about it, since it never gets the message from the user code container.
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
- If the job posting fails 5 times (e.g. result too large) then the client tries 5 more times to post just a simple error message.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

## Are Docs needed?
<!-- Please indicate whether documentation is needed for this PR. -->
