### PR TITLE
Drop 3.9 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ workflows:
           name: python-<< matrix.python_version>>
           matrix:
             parameters:
-              python_version: ["3.9", "3.10", "3.11", "3.12"]
+              python_version: ["3.10", "3.11", "3.12"]
       - mypy:
         <<: *always-run
       - check_format:
@@ -77,7 +77,6 @@ workflows:
       - circle-all:
           <<: *always-run
           requires:
-            - python-3.9
             - python-3.10
             - python-3.11
             - python-3.12

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -4,7 +4,7 @@
 
 ## Requirements
 
-* python >= 3.9
+* python >= 3.10
 * [poetry](https://python-poetry.org/docs/)
 
 ## Commands

--- a/compute_modules/logging/common.py
+++ b/compute_modules/logging/common.py
@@ -114,6 +114,7 @@ class ComputeModulesLoggerAdapter(_LoggerAdapter):
         logger_name: str,
     ) -> None:
         # Need to pass empty dict as `extra` param for 3.9 support
+        # TODO: update since 3.9 is no longer supported
         super().__init__(_create_logger(logger_name), dict())
 
     def process(self, msg: Any, kwargs: MutableMapping[str, Any]) -> Tuple[Any, MutableMapping[str, Any]]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ keywords = ["Palantir", "Foundry", "Compute Modules"]
 packages = [{ include = "compute_modules" }]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 requests = "^2.32.3"
 external-systems = {version = "^0.108.0", extras = ["sources"]}
 pyyaml = { version = "^6.0.1", optional = true }


### PR DESCRIPTION
Python 3.9 reached EOL https://devguide.python.org/versions/

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Drop 3.9 support
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

