### PR TITLE
Cap RefreshingOauthToken refresh interval at token expiry

### DIFF
--- a/compute_modules/auth/third_party.py
+++ b/compute_modules/auth/third_party.py
@@ -19,7 +19,7 @@ import os
 import ssl
 import time
 import urllib.parse
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 
 def retrieve_third_party_id_and_creds() -> Tuple[Optional[str], Optional[str]]:
@@ -28,7 +28,7 @@ def retrieve_third_party_id_and_creds() -> Tuple[Optional[str], Optional[str]]:
     return CLIENT_ID, CLIENT_SECRET
 
 
-def oauth(hostname: str, scope: List[str]) -> Any:
+def _request_oauth_token(hostname: str, scope: List[str]) -> Optional[Dict[str, Any]]:
     CLIENT_ID, CLIENT_SECRET = retrieve_third_party_id_and_creds()
     if CLIENT_ID and CLIENT_SECRET:
         params = urllib.parse.urlencode(
@@ -53,10 +53,17 @@ def oauth(hostname: str, scope: List[str]) -> Any:
             try:
                 token_data = json.loads(data)
                 if isinstance(token_data, dict):
-                    return token_data.get("access_token")
+                    return token_data
             except (ValueError, KeyError):
                 return None
     return None
+
+
+def oauth(hostname: str, scope: List[str]) -> Any:
+    token_data = _request_oauth_token(hostname, scope)
+    if token_data is None:
+        return None
+    return token_data.get("access_token")
 
 
 class RefreshingOauthToken:
@@ -64,15 +71,19 @@ class RefreshingOauthToken:
         self.hostname = hostname
         self.scope = scope
         self.refresh_interval = refresh_interval
-        self.last_refresh_time = 0.0
-        self.token = None
+        self.next_refresh_time = 0.0
+        self.token: Optional[str] = None
 
     def get_token(self) -> Any:
         current_time = time.time()
-        if not self.token or current_time - self.last_refresh_time > self.refresh_interval:
-            self.token = self._fetch_token()
-            self.last_refresh_time = current_time
+        if not self.token or current_time >= self.next_refresh_time:
+            token_data = _request_oauth_token(self.hostname, self.scope) or {}
+            self.token = token_data.get("access_token")
+            self.next_refresh_time = current_time + self._effective_refresh_interval(token_data)
         return self.token
 
-    def _fetch_token(self) -> Any:
-        return oauth(self.hostname, self.scope)
+    def _effective_refresh_interval(self, token_data: Dict[str, Any]) -> float:
+        expires_in = token_data.get("expires_in")
+        if isinstance(expires_in, (int, float)) and expires_in > 0:
+            return min(self.refresh_interval, float(expires_in))
+        return float(self.refresh_interval)

--- a/tests/auth/test_third_party.py
+++ b/tests/auth/test_third_party.py
@@ -28,7 +28,7 @@ MOCK_TOKEN: str = "mock_token"
 
 @pytest.fixture
 def mock_oauth() -> Generator[MagicMock, None, None]:
-    with patch("compute_modules.auth.third_party.oauth") as mock_oauth:
+    with patch("compute_modules.auth.third_party._request_oauth_token") as mock_oauth:
         yield mock_oauth
 
 
@@ -39,7 +39,7 @@ def mock_time() -> Generator[MagicMock, None, None]:
 
 
 def test_get_token_initial_fetch(mock_oauth: MagicMock, mock_time: MagicMock) -> None:
-    mock_oauth.return_value = MOCK_TOKEN
+    mock_oauth.return_value = {"access_token": MOCK_TOKEN}
     mock_time.return_value = 1000
 
     token_refresher = RefreshingOauthToken(MOCK_HOSTNAME, MOCK_SCOPE)
@@ -50,7 +50,7 @@ def test_get_token_initial_fetch(mock_oauth: MagicMock, mock_time: MagicMock) ->
 
 
 def test_get_token_refresh_needed(mock_oauth: MagicMock, mock_time: MagicMock) -> None:
-    mock_oauth.return_value = MOCK_TOKEN
+    mock_oauth.return_value = {"access_token": MOCK_TOKEN}
     initial_time: int = 1000
     mock_time.side_effect = [initial_time, initial_time + 1900]  # Outside refresh interval
 
@@ -63,7 +63,7 @@ def test_get_token_refresh_needed(mock_oauth: MagicMock, mock_time: MagicMock) -
 
 
 def test_get_token_no_refresh_needed(mock_oauth: MagicMock, mock_time: MagicMock) -> None:
-    mock_oauth.return_value = MOCK_TOKEN
+    mock_oauth.return_value = {"access_token": MOCK_TOKEN}
     initial_time: int = 1000
     mock_time.side_effect = [initial_time, initial_time + 1700]  # Within refresh interval
 
@@ -72,4 +72,32 @@ def test_get_token_no_refresh_needed(mock_oauth: MagicMock, mock_time: MagicMock
     token: str = token_refresher.get_token()  # Should not trigger refresh
 
     assert token == MOCK_TOKEN
+    assert mock_oauth.call_count == 1
+
+
+def test_get_token_refreshes_at_token_expiry_when_refresh_interval_exceeds_expiry(
+    mock_oauth: MagicMock, mock_time: MagicMock
+) -> None:
+    mock_oauth.return_value = {"access_token": MOCK_TOKEN, "expires_in": 300}
+    initial_time: int = 1000
+    mock_time.side_effect = [initial_time, initial_time + 301]
+
+    token_refresher = RefreshingOauthToken(MOCK_HOSTNAME, MOCK_SCOPE, refresh_interval=1800)
+    token_refresher.get_token()
+    token_refresher.get_token()
+
+    assert mock_oauth.call_count == 2
+
+
+def test_get_token_uses_refresh_interval_when_shorter_than_token_expiry(
+    mock_oauth: MagicMock, mock_time: MagicMock
+) -> None:
+    mock_oauth.return_value = {"access_token": MOCK_TOKEN, "expires_in": 3600}
+    initial_time: int = 1000
+    mock_time.side_effect = [initial_time, initial_time + 1700]
+
+    token_refresher = RefreshingOauthToken(MOCK_HOSTNAME, MOCK_SCOPE, refresh_interval=1800)
+    token_refresher.get_token()
+    token_refresher.get_token()
+
     assert mock_oauth.call_count == 1


### PR DESCRIPTION
## Before this PR

`RefreshingOauthToken` could refresh on a user-supplied interval longer than the OAuth token's `expires_in`, causing it to return an expired token. Fixes #61.

## After this PR
==COMMIT_MSG==
`RefreshingOauthToken` caps its refresh interval at the token's `expires_in`.
==COMMIT_MSG==

## Possible downsides?

If a provider returns a small `expires_in`, the token will refresh more often than the configured interval. This is the intended behavior.