### PR TITLE
Add Scratch package

### DIFF
--- a/foundrycache/__init__.py
+++ b/foundrycache/__init__.py
@@ -1,0 +1,23 @@
+#  Copyright 2026 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from foundrycache._cache import DistributedCache
+from foundrycache._lock import DistributedLock
+from foundrycache._types import CacheTTL
+
+__all__ = [
+    "CacheTTL",
+    "DistributedCache",
+    "DistributedLock",
+]

--- a/foundrycache/_cache.py
+++ b/foundrycache/_cache.py
@@ -1,0 +1,90 @@
+#  Copyright 2026 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""DistributedCache — the main user-facing class for caching operations."""
+
+from typing import Callable, Optional
+
+from foundrycache._client import CachingServiceClient, _get_default_client
+from foundrycache._types import CacheTTL
+
+
+class DistributedCache:
+    """A distributed cache for deployed compute workloads.
+
+    Data expires after a configurable TTL (default 1 hour, max 24 hours)
+    and carries no durability guarantees.
+
+    Example usage::
+
+        from foundrycache import DistributedCache, CacheTTL
+        import json
+
+        cache = DistributedCache()
+
+        result = cache.get_or_compute(
+            key=f"product:{product_id}",
+            fallback=lambda: json.dumps(fetch_product(product_id)),
+        )
+
+        cache.put("result:overhead", json.dumps({"total": 42.5}), ttl=CacheTTL.SIX_HOURS)
+
+        cache.put_expected("counter", new_value="6", expected="5")
+
+        results = cache.batch_get(["key1", "key2", "key3"])
+    """
+
+    def __init__(self, service_url: Optional[str] = None, compute_rid: Optional[str] = None) -> None:
+        if service_url is not None or compute_rid is not None:
+            self._client = CachingServiceClient(service_url=service_url, compute_rid=compute_rid)
+        else:
+            self._client = _get_default_client()
+
+    def get_or_compute(self, key: str, fallback: Callable[[], str], ttl: CacheTTL = CacheTTL.ONE_HOUR) -> str:
+        """Return cached value if it exists, otherwise compute, store, and return it.
+
+        The fallback is called client-side, then sent to the server which atomically
+        checks-and-stores. Under concurrent access from multiple replicas, the fallback
+        may execute more than once but only one value will be stored.
+        """
+        value = fallback()
+        result_value, _was_computed = self._client.get_or_compute(key, value, ttl)
+        return result_value
+
+    def put(self, key: str, value: str, ttl: CacheTTL = CacheTTL.ONE_HOUR) -> None:
+        """Write a value to the cache."""
+        self._client.put(key, value, ttl)
+
+    def put_expected(
+        self, key: str, new_value: str, expected: Optional[str] = None, ttl: CacheTTL = CacheTTL.ONE_HOUR
+    ) -> bool:
+        """Compare-and-swap: atomically update only if current value matches expected.
+
+        If expected is None, acts as put-if-absent (only writes if the key does not exist).
+
+        Returns True if the value was updated, False if the condition was not met.
+        """
+        return self._client.put_expected(key, expected, new_value, ttl)
+
+    def delete(self, key: str) -> None:
+        """Remove a key from the cache. No-op if absent."""
+        self._client.delete(key)
+
+    def exists(self, key: str) -> bool:
+        """Check if a key exists without retrieving the value."""
+        return self._client.exists(key)
+
+    def batch_get(self, keys: list[str]) -> dict[str, str]:
+        """Retrieve multiple keys in one call (max 100). Missing keys omitted."""
+        return self._client.batch_get(keys)

--- a/foundrycache/_client.py
+++ b/foundrycache/_client.py
@@ -1,0 +1,165 @@
+#  Copyright 2026 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Low-level HTTP client for the Caching Service Conjure API."""
+
+import json
+import os
+from functools import cache
+from typing import Any, Optional
+from urllib.parse import quote
+
+import requests
+
+from foundrycache._types import CacheError, CacheTTL, CacheUnavailableError, RateLimitedError
+
+EPHEMERAL_CACHE_URL = "EPHEMERAL_CACHE_URL"
+EPHEMERAL_CACHE_TOKEN = "EPHEMERAL_CACHE_TOKEN"
+FOUNDRY_COMPUTE_MODULE_RID = "FOUNDRY_COMPUTE_MODULE_RID"
+
+
+@cache
+def _get_default_client() -> "CachingServiceClient":
+    """Lazily create a shared client from environment variables."""
+    return CachingServiceClient()
+
+
+class CachingServiceClient:
+    """HTTP client that calls the Caching Service Conjure API."""
+
+    def __init__(
+        self,
+        service_url: Optional[str] = None,
+        compute_rid: Optional[str] = None,
+    ) -> None:
+        self._service_url = (service_url or os.environ.get(EPHEMERAL_CACHE_URL, "")).rstrip("/")
+        self._compute_rid = compute_rid or os.environ.get(FOUNDRY_COMPUTE_MODULE_RID, "")
+        self._auth_token = os.environ.get(EPHEMERAL_CACHE_TOKEN, "Bearer prototype")
+
+        if not self._service_url:
+            raise CacheError(
+                f"Cache service URL not configured. Set {EPHEMERAL_CACHE_URL} environment variable or pass service_url."
+            )
+        if not self._compute_rid:
+            raise CacheError(
+                f"Compute RID not configured. Set {FOUNDRY_COMPUTE_MODULE_RID} environment variable or pass compute_rid."
+            )
+
+    @property
+    def compute_rid(self) -> str:
+        return self._compute_rid
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": self._auth_token,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    def _handle_response(self, resp: requests.Response) -> Any:
+        if resp.status_code == 429:
+            raise RateLimitedError(self._compute_rid)
+        if resp.status_code >= 500:
+            raise CacheUnavailableError(f"Cache service error: {resp.status_code}")
+        resp.raise_for_status()
+        if resp.status_code == 204 or not resp.content:
+            return None
+        return resp.json()
+
+    def _url(self, path: str) -> str:
+        return f"{self._service_url}/ephemeral-cache/api{path}"
+
+    # -- Cache operations --
+
+    def get(self, key: str) -> Optional[str]:
+        rid = quote(self._compute_rid, safe="")
+        k = quote(key, safe="")
+        resp = requests.get(self._url(f"/v1/cache/{rid}/{k}"), headers=self._headers())
+        if resp.status_code == 204 or not resp.content:
+            return None
+        data = self._handle_response(resp)
+        if data is None:
+            return None
+        return data.get("value")  # type: ignore[no-any-return]
+
+    def put(self, key: str, value: str, ttl: Optional[CacheTTL] = None) -> None:
+        body: dict[str, Any] = {"computeRid": self._compute_rid, "key": key, "value": {"value": value}}
+        if ttl is not None:
+            body["ttl"] = ttl.value
+        resp = requests.post(self._url("/v1/cache"), headers=self._headers(), data=json.dumps(body))
+        self._handle_response(resp)
+
+    def get_or_compute(self, key: str, fallback_value: str, ttl: Optional[CacheTTL] = None) -> tuple[str, bool]:
+        body: dict[str, Any] = {"computeRid": self._compute_rid, "key": key, "fallbackValue": {"value": fallback_value}}
+        if ttl is not None:
+            body["ttl"] = ttl.value
+        resp = requests.post(self._url("/v1/cache/get-or-compute"), headers=self._headers(), data=json.dumps(body))
+        data = self._handle_response(resp)
+        return data["value"]["value"], data["wasComputed"]  # type: ignore[no-any-return]
+
+    def put_expected(self, key: str, expected: Optional[str], new_value: str, ttl: Optional[CacheTTL] = None) -> bool:
+        body: dict[str, Any] = {"computeRid": self._compute_rid, "key": key, "newValue": {"value": new_value}}
+        if expected is not None:
+            body["expected"] = {"value": expected}
+        if ttl is not None:
+            body["ttl"] = ttl.value
+        resp = requests.post(self._url("/v1/cache/put-expected"), headers=self._headers(), data=json.dumps(body))
+        data = self._handle_response(resp)
+        return data.get("success", False)  # type: ignore[no-any-return]
+
+    def delete(self, key: str) -> None:
+        rid = quote(self._compute_rid, safe="")
+        k = quote(key, safe="")
+        resp = requests.delete(self._url(f"/v1/cache/{rid}/{k}"), headers=self._headers())
+        self._handle_response(resp)
+
+    def exists(self, key: str) -> bool:
+        rid = quote(self._compute_rid, safe="")
+        k = quote(key, safe="")
+        resp = requests.get(self._url(f"/v1/cache/{rid}/{k}/exists"), headers=self._headers())
+        return self._handle_response(resp) is True
+
+    def batch_get(self, keys: list[str]) -> dict[str, str]:
+        body: dict[str, Any] = {"computeRid": self._compute_rid, "keys": keys}
+        resp = requests.post(self._url("/v1/cache/batch-get"), headers=self._headers(), data=json.dumps(body))
+        data = self._handle_response(resp)
+        if data is None:
+            return {}
+        entries: dict[str, Any] = data.get("entries", {})
+        return {k: v["value"] for k, v in entries.items()}
+
+    # -- Lock operations --
+
+    def try_lock(self, lock_name: str) -> Optional[dict[str, Any]]:
+        body: dict[str, Any] = {"computeRid": self._compute_rid, "lockName": lock_name}
+        resp = requests.post(self._url("/v1/lock/try-lock"), headers=self._headers(), data=json.dumps(body))
+        data = self._handle_response(resp)
+        if data is None:
+            return None
+        if "acquired" in data:
+            return data["acquired"]  # type: ignore[no-any-return]
+        return None
+
+    def unlock(self, handle: dict[str, Any]) -> None:
+        body: dict[str, Any] = {"computeRid": self._compute_rid, "handle": handle}
+        resp = requests.post(self._url("/v1/lock/unlock"), headers=self._headers(), data=json.dumps(body))
+        self._handle_response(resp)
+
+    def refresh_lock(self, handle: dict[str, Any]) -> bool:
+        body: dict[str, Any] = {"computeRid": self._compute_rid, "handle": handle}
+        resp = requests.post(self._url("/v1/lock/refresh"), headers=self._headers(), data=json.dumps(body))
+        data = self._handle_response(resp)
+        if data is None:
+            return False
+        return data.get("success", False)  # type: ignore[no-any-return]

--- a/foundrycache/_lock.py
+++ b/foundrycache/_lock.py
@@ -1,0 +1,98 @@
+#  Copyright 2026 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""DistributedLock — cross-replica coordination primitives."""
+
+from typing import Any, Optional
+
+from foundrycache._client import CachingServiceClient, _get_default_client
+
+
+class Lock:
+    """A held distributed lock. Auto-expires in 5 seconds if not refreshed.
+
+    Can be used as a context manager::
+
+        lock_service = DistributedLock()
+        maybe_lock = lock_service.try_lock("my-lock")
+        if maybe_lock:
+            with maybe_lock:
+                do_work()
+    """
+
+    def __init__(self, client: CachingServiceClient, handle: dict[str, Any]) -> None:
+        self._client = client
+        self._handle = handle
+        self._released = False
+
+    @property
+    def lock_name(self) -> str:
+        return self._handle["lockName"]  # type: ignore[no-any-return]
+
+    @property
+    def lock_id(self) -> str:
+        return self._handle["lockId"]  # type: ignore[no-any-return]
+
+    def unlock(self) -> None:
+        """Release the lock synchronously."""
+        if not self._released:
+            self._client.unlock(self._handle)
+            self._released = True
+
+    def refresh(self) -> bool:
+        """Extend the lease by another 5 seconds. Returns False if the lock was lost."""
+        if self._released:
+            return False
+        return self._client.refresh_lock(self._handle)
+
+    def __enter__(self) -> "Lock":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.unlock()
+
+
+class DistributedLock:
+    """Distributed locking for cross-replica coordination.
+
+    Locks auto-expire after 5 seconds if not refreshed.
+
+    Example usage::
+
+        from foundrycache import DistributedLock
+
+        lock = DistributedLock()
+        maybe_lock = lock.try_lock("process-batch")
+        if maybe_lock:
+            try:
+                for chunk in get_chunks():
+                    process(chunk)
+                    if not maybe_lock.refresh():
+                        raise RuntimeError("Lost lock")
+            finally:
+                maybe_lock.unlock()
+    """
+
+    def __init__(self, service_url: Optional[str] = None, compute_rid: Optional[str] = None) -> None:
+        if service_url is not None or compute_rid is not None:
+            self._client = CachingServiceClient(service_url=service_url, compute_rid=compute_rid)
+        else:
+            self._client = _get_default_client()
+
+    def try_lock(self, lock_name: str) -> Optional[Lock]:
+        """Attempt to acquire a named lock. Returns Lock if acquired, None if contended."""
+        handle = self._client.try_lock(lock_name)
+        if handle is None:
+            return None
+        return Lock(self._client, handle)

--- a/foundrycache/_types.py
+++ b/foundrycache/_types.py
@@ -1,0 +1,47 @@
+#  Copyright 2026 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from enum import Enum
+
+
+class CacheTTL(Enum):
+    """Allowed TTL values for cache entries.
+
+    Enforces the maximum 24-hour TTL and prevents runtime errors from invalid durations.
+    """
+
+    TEN_SECONDS = "TEN_SECONDS"
+    ONE_MINUTE = "ONE_MINUTE"
+    FIVE_MINUTES = "FIVE_MINUTES"
+    FIFTEEN_MINUTES = "FIFTEEN_MINUTES"
+    ONE_HOUR = "ONE_HOUR"
+    SIX_HOURS = "SIX_HOURS"
+    TWELVE_HOURS = "TWELVE_HOURS"
+    ONE_DAY = "ONE_DAY"
+
+
+class CacheError(Exception):
+    """Base exception for cache operations."""
+
+
+class CacheUnavailableError(CacheError):
+    """Raised when the cache service is unreachable."""
+
+
+class RateLimitedError(CacheError):
+    """Raised when the rate limit is exceeded."""
+
+    def __init__(self, compute_rid: str) -> None:
+        super().__init__(f"Rate limit exceeded for compute RID: {compute_rid}")
+        self.compute_rid = compute_rid


### PR DESCRIPTION
## After this PR
Adds a scratch Python package, providing DistributedCache and DistributedLock classes for compute modules to use the scratch service.                                       
   
 Package structure:                                                                                                                                                                                             
  - scratch/_types.py: CacheTTL enum, exception hierarchy (CacheError, ScratchNotEnabledError, CacheUnavailableError, RateLimitedError)                                                                       
  - scratch/_client.py: ScratchClient low-level HTTP client (service discovery via FOUNDRY_SERVICE_DISCOVERY_V2, auth via SCRATCH_TOKEN)                                                                        
  - scratch/_cache.py: DistributedCache user-facing class (get, put, delete, exists, batch_get)
  - scratch/_lock.py: DistributedLock + Lock user-facing classes (try_lock, unlock, refresh, context manager)                                                                                                   
                                                                                                                                                                                                               
  Feature gating:                                                                                                                                                                                                
  - DistributedCache() and DistributedLock() raise ScratchNotEnabledError at construction time if the SCRATCH_TOKEN env var is not present (injected by to the CM when scratch is enabled on the stack/for the compute module)                                                                                                                       
                                                                                                                                                                                                                 
  Service discovery:                                                                                                                                                                                             
  - Resolves the scratch service URL from FOUNDRY_SERVICE_DISCOVERY_V2 (compute mesh), reading the contour_backend_multiplexer entry                                                                           
  - A service_url constructor param is available as override for testing                                                                                                                                         
   
Note: The URL paths (/scratch/api/v1/cache, /scratch/api/v1/lock/...) are currently hardcoded in the client. This is consistent with how internal_query_client.py handles its endpoints in this SDK. If scratch is extracted into a shared package in the future, these could be replaced with a generated Conjure Python client, but should be fine for v0.                 

==COMMIT_MSG==
Add Scratch package
==COMMIT_MSG==


