### PR TITLE
Add params, unsafe_params and bounded context

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ You can add SLS safe logging params to an individual log line with the `params` 
 with the SDK-provided `process_id`, `job_id`, and `session_id` values.
 
 ```python
+import logging
 from compute_modules.logging import get_logger
 
 logger = get_logger(__name__)

--- a/README.md
+++ b/README.md
@@ -437,6 +437,39 @@ logger.error("Peekaboo!")
 logger.critical("Peekaboo!")
 ```
 
+You can add SLS safe logging params to an individual log line with the `params` keyword. Params are merged
+with the SDK-provided `process_id`, `job_id`, and `session_id` values.
+
+```python
+from compute_modules.logging import get_logger
+
+logger = get_logger(__name__)
+logger.setLevel(logging.INFO)
+
+logger.info("Processed event", params={"event_primary_key": event_primary_key, "row_count": row_count})
+```
+
+For context that should be included on many log lines, bind it once. Bound params are copied into a new logger
+adapter, and per-call params with the same key take precedence.
+
+```python
+request_logger = logger.bind(params={"trace_id": trace_id, "event_primary_key": event_primary_key})
+
+request_logger.info("Started processing")
+request_logger.info("Finished processing", params={"duration_ms": duration_ms})
+```
+
+Unsafe params can be logged separately using the `unsafe_params` keyword. When unsafe params are present, they
+are written to the SLS `unsafeParams` field and the log entry is not marked `safe`.
+
+```python
+request_logger.info(
+    "Received request",
+    params={"request_type": request_type},
+    unsafe_params={"display_name": display_name},
+)
+```
+
 ### Applying your own custom log formatter via the SDK
 
 If you would like to use the SDK logging but apply your own formatter, you can use the utility function provided. 

--- a/changelog/@unreleased/pr-logging-params.v2.yml
+++ b/changelog/@unreleased/pr-logging-params.v2.yml
@@ -1,0 +1,4 @@
+type: improvement
+improvement:
+  description: Add dictionary-based safe and unsafe SLS logging params, plus bound logging context.
+  links: []

--- a/compute_modules/logging/common.py
+++ b/compute_modules/logging/common.py
@@ -62,7 +62,7 @@ class SlsFormatter(logging.Formatter):
             log_entry[SLS_UNSAFE_PARAMS_KEY] = unsafe_params
         else:
             log_entry["safe"] = True
-        return json.dumps(log_entry)
+        return json.dumps(log_entry, default=str)
 
 
 SLS_FORMATTER = SlsFormatter()

--- a/compute_modules/logging/common.py
+++ b/compute_modules/logging/common.py
@@ -17,8 +17,9 @@ import json
 import logging
 import os
 import threading
+from collections.abc import Mapping, MutableMapping
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Dict, MutableMapping, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any
 
 # logging.LoggerAdapter was made generic in 3.11 so we need to determine at runtime
 # whether this should be generic or not.
@@ -32,6 +33,8 @@ else:
 
 DEFAULT_LOG_FORMAT = "%(message)s"
 DEFAULT_LOG_STRING_FORMATTER = logging.Formatter(DEFAULT_LOG_FORMAT)
+SLS_PARAMS_KEY = "params"
+SLS_UNSAFE_PARAMS_KEY = "unsafeParams"
 
 
 class SlsFormatter(logging.Formatter):
@@ -45,16 +48,20 @@ class SlsFormatter(logging.Formatter):
         # Use the default string formatter for the message field
         formatted_message = self.string_formatter.format(record)
 
+        unsafe_params = getattr(record, SLS_UNSAFE_PARAMS_KEY, {})
         log_entry = {
             "type": getattr(record, "service_type", "service.1"),
             "level": record.levelname,
             "time": datetime.now(timezone.utc).isoformat(),
             "origin": f"{record.filename}:{record.lineno}",
-            "safe": True,
             "thread": threading.current_thread().name,
-            "params": getattr(record, "params", {}),
+            SLS_PARAMS_KEY: getattr(record, SLS_PARAMS_KEY, {}),
             "message": formatted_message,
         }
+        if unsafe_params:
+            log_entry[SLS_UNSAFE_PARAMS_KEY] = unsafe_params
+        else:
+            log_entry["safe"] = True
         return json.dumps(log_entry)
 
 
@@ -101,6 +108,45 @@ def get_thread_local_data(key: str, default: str) -> str:
     return getattr(THREAD_LOCAL, key, default)
 
 
+def _copy_mapping(name: str, value: object) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{name} must be a mapping, got {type(value).__name__}")
+    return dict(value)
+
+
+def _pop_mapping(kwargs: MutableMapping[str, Any], name: str) -> dict[str, Any]:
+    return _copy_mapping(name, kwargs.pop(name, None))
+
+
+def _remove_unsafe_keys(params: dict[str, Any], unsafe_params: Mapping[str, Any]) -> None:
+    for key in unsafe_params:
+        params.pop(key, None)
+
+
+def _runtime_params() -> dict[str, str]:
+    return {
+        "process_id": str(get_thread_local_data("process_id", "-1")),
+        "job_id": str(get_thread_local_data("job_id", "")),
+        "session_id": os.environ.get("COMPUTE_SESSION_ID", ""),
+    }
+
+
+def _log_record_extra(
+    extra: object,
+    runtime_params: Mapping[str, str],
+    params: Mapping[str, Any],
+    unsafe_params: Mapping[str, Any],
+) -> dict[str, Any]:
+    record_extra = _copy_mapping("extra", extra)
+    record_extra.update(runtime_params)
+    record_extra[SLS_PARAMS_KEY] = dict(params)
+    if unsafe_params:
+        record_extra[SLS_UNSAFE_PARAMS_KEY] = dict(unsafe_params)
+    return record_extra
+
+
 # Custom LoggerAdapter to inject job- & thread/process-specific information into log lines
 #
 # See: https://docs.python.org/3/howto/logging-cookbook.html#using-loggeradapters-to-impart-contextual-information
@@ -112,28 +158,61 @@ class ComputeModulesLoggerAdapter(_LoggerAdapter):
     def __init__(
         self,
         logger_name: str,
+        params: Mapping[str, Any] | None = None,
+        unsafe_params: Mapping[str, Any] | None = None,
+        logger: logging.Logger | None = None,
     ) -> None:
-        # Need to pass empty dict as `extra` param for 3.9 support
-        # TODO: update since 3.9 is no longer supported
-        super().__init__(_create_logger(logger_name), dict())
+        super().__init__(logger if logger else _create_logger(logger_name), {})
+        self._params = _copy_mapping("params", params)
+        self._unsafe_params = _copy_mapping("unsafe_params", unsafe_params)
 
-    def process(self, msg: Any, kwargs: MutableMapping[str, Any]) -> Tuple[Any, MutableMapping[str, Any]]:
-        custom_data = {
-            "process_id": str(get_thread_local_data("process_id", "-1")),
-            "job_id": str(get_thread_local_data("job_id", "")),
-            "session_id": os.environ.get("COMPUTE_SESSION_ID", ""),
+    def bind(
+        self,
+        params: Mapping[str, Any] | None = None,
+        unsafe_params: Mapping[str, Any] | None = None,
+    ) -> "ComputeModulesLoggerAdapter":
+        """Return a logger adapter with params added to every SLS log entry.
+
+        Bound params are immutable defaults: per-call params with the same key
+        take precedence.
+        """
+        merged_params = {
+            **self._params,
+            **_copy_mapping("params", params),
         }
-        kwargs["extra"] = kwargs.get("extra", {})
-        kwargs["extra"].update(custom_data)
-        kwargs["extra"]["params"] = custom_data
+        merged_unsafe_params = {
+            **self._unsafe_params,
+            **_copy_mapping("unsafe_params", unsafe_params),
+        }
+        return ComputeModulesLoggerAdapter(
+            self.logger.name,
+            params=merged_params,
+            unsafe_params=merged_unsafe_params,
+            logger=self.logger,
+        )
+
+    def process(self, msg: Any, kwargs: MutableMapping[str, Any]) -> tuple[Any, MutableMapping[str, Any]]:
+        runtime_params = _runtime_params()
+        params = {
+            **runtime_params,
+            **self._params,
+            **_pop_mapping(kwargs, SLS_PARAMS_KEY),
+        }
+        unsafe_params = {
+            **self._unsafe_params,
+            **_pop_mapping(kwargs, "unsafe_params"),
+        }
+        _remove_unsafe_keys(params, unsafe_params)
+
+        kwargs["extra"] = _log_record_extra(kwargs.get("extra"), runtime_params, params, unsafe_params)
 
         return msg, kwargs
 
 
 class ComputeModulesAdapterManager(object):
-    adapters: Dict[str, ComputeModulesLoggerAdapter] = {}
+    adapters: dict[str, ComputeModulesLoggerAdapter] = {}
 
-    def get_logger(self, name: str, default_level: Optional[Union[str, int]] = None) -> ComputeModulesLoggerAdapter:
+    def get_logger(self, name: str, default_level: str | int | None = None) -> ComputeModulesLoggerAdapter:
         """Get a logger by name. If it does not already exist, creates it first"""
         if name not in self.adapters:
             self.adapters[name] = ComputeModulesLoggerAdapter(name)

--- a/tests/logging/test_log_context.py
+++ b/tests/logging/test_log_context.py
@@ -20,7 +20,7 @@ import uuid
 import pytest
 
 from compute_modules.logging import get_logger, internal, setup_logger_formatter
-from compute_modules.logging.common import COMPUTE_MODULES_ADAPTER_MANAGER, ComputeModulesLoggerAdapter
+from compute_modules.logging.common import COMPUTE_MODULES_ADAPTER_MANAGER, ComputeModulesLoggerAdapter, SlsFormatter
 from tests.conftest import JsonFormatter
 
 from .logging_test_utils import CLIENT_ERROR_STR, CLIENT_INFO_STR, CLIENT_WARNING_STR, INFO_STR
@@ -49,8 +49,69 @@ def assert_log_params(log: str, process_id: int, job_id: str, session_id: str = 
     assert params["session_id"] == session_id, f"Expected session_id {session_id}, got {params['session_id']}"
 
 
+def test_log_params_can_be_added_per_call(capsys: pytest.CaptureFixture[str]) -> None:
+    setup_logger_formatter(SlsFormatter())
+    COMPUTE_MODULES_ADAPTER_MANAGER.update_process_id(PROCESS_ID)
+    COMPUTE_MODULES_ADAPTER_MANAGER.update_job_id("")
+
+    logger = get_logger("test.logger.params-per-call")
+    logger.setLevel(logging.INFO)
+    logger.info("with params", params={"event_primary_key": "event-1", "row_count": 5})
+
+    logged = json.loads(capsys.readouterr().err)
+    assert logged["safe"] is True
+    assert logged["params"]["event_primary_key"] == "event-1"
+    assert logged["params"]["row_count"] == 5
+    assert logged["params"]["process_id"] == str(PROCESS_ID)
+    assert logged["params"]["job_id"] == ""
+
+
+def test_bound_params_are_added_to_every_log_and_per_call_params_win(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    setup_logger_formatter(SlsFormatter())
+    COMPUTE_MODULES_ADAPTER_MANAGER.update_process_id(PROCESS_ID)
+    COMPUTE_MODULES_ADAPTER_MANAGER.update_job_id("")
+
+    logger = get_logger("test.logger.bound-params")
+    logger.setLevel(logging.INFO)
+    bound_logger = logger.bind(params={"trace_id": "trace-1", "event_primary_key": "default-event"})
+
+    logger.info("without bound params")
+    bound_logger.info("with bound params", params={"event_primary_key": "event-2"})
+
+    logged = [json.loads(line) for line in capsys.readouterr().err.splitlines()]
+    assert "trace_id" not in logged[0]["params"]
+    assert logged[1]["params"]["trace_id"] == "trace-1"
+    assert logged[1]["params"]["event_primary_key"] == "event-2"
+
+
+def test_unsafe_params_are_written_to_unsafe_params_and_mark_log_unsafe(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    setup_logger_formatter(SlsFormatter())
+    COMPUTE_MODULES_ADAPTER_MANAGER.update_process_id(PROCESS_ID)
+    COMPUTE_MODULES_ADAPTER_MANAGER.update_job_id("")
+
+    logger = get_logger("test.logger.unsafe-params")
+    logger.setLevel(logging.INFO)
+    logger.info(
+        "with unsafe params",
+        params={"dataset_rid": "ri.foundry.main.dataset.123", "dataset_name": "should-not-be-safe"},
+        unsafe_params={"dataset_name": "Customers"},
+    )
+
+    logged = json.loads(capsys.readouterr().err)
+    assert "safe" not in logged
+    assert logged["params"]["dataset_rid"] == "ri.foundry.main.dataset.123"
+    assert "dataset_name" not in logged["params"]
+    assert logged["unsafeParams"]["dataset_name"] == "Customers"
+
+
 def test_log_format(capsys: pytest.CaptureFixture[str], custom_formatter: JsonFormatter) -> None:
     """Verify initial state of logger context"""
+    COMPUTE_MODULES_ADAPTER_MANAGER.update_process_id(process_id=-1)
+    COMPUTE_MODULES_ADAPTER_MANAGER.update_job_id(job_id="")
     internal_logger, logger_1, logger_2 = logger_fixtures()
     internal_logger.info(INFO_STR)
     logger_1.info(CLIENT_INFO_STR)


### PR DESCRIPTION
## Before this PR

Python Compute Module loggers always populated the SLS `params` object with SDK-managed context like `process_id`, `job_id`, and `session_id`, but callers could not add their own structured SLS params through the public logging API.

It also meant unsafe values had no clear API and no separation from safe params. Callers who needed repeated request-scoped context had to build local `LoggerAdapter` wrappers or repeat the same params on every log call.

## After this PR

Compute Module loggers now support user-provided SLS logging params:

- `logger.info("message", params={...})` adds safe params to the SLS `params` field.
- `logger.info("message", unsafe_params={...})` adds unsafe params to the SLS `unsafeParams` field.
- `logger.bind(params={...}, unsafe_params={...})` returns a new logger adapter with bound context included on every log line.

This gives Python Compute Modules a first-class way to emit structured SLS log context without requiring users to implement their own logger adapter.

## Possible downsides?

Callers now need to understand the difference between safe `params` and unsafe `unsafe_params`, and should avoid placing user-controlled or sensitive values in `params`.

When unsafe params are present, the emitted SLS log entry is not marked `safe`, matching the intent that unsafe/user-controlled values should not be indexed as safe log content.