### PR TITLE
Add Scratch package

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,57 @@ INFO: raw_args: ['--test', 'hello', '--another-param', 'world']
 INFO: parsed_args: Namespace(test='hello' , another_param= 'world' )
 ```
 
+## Scratch: Distributed Cache & Locking
+
+The `scratch` package provides a distributed cache and distributed locking primitives shared across all replicas of a 
+compute module. Install the scratch extras to use it:
+
+```bash
+pip install foundry-compute-modules[scratch]
+```
+
+### Distributed Cache
+
+```python
+from scratch import DistributedCache, CacheTTL
+import json
+
+cache = DistributedCache(default_ttl=CacheTTL.FIVE_MINUTES)
+
+# Write to cache
+cache.put("my-key", json.dumps({"result": 42}))
+
+# Read from cache (returns None if missing or expired)
+value = cache.get("my-key")
+
+# Batch read (up to 100 keys)
+values = cache.batch_get(["key1", "key2", "key3"])
+
+# Override default TTL for a specific write
+cache.put("long-lived", "data", ttl=CacheTTL.ONE_DAY)
+```
+
+Data expires after the configured TTL (max 24 hours) and carries no durability guarantees.
+
+### Distributed Lock
+
+```python
+from scratch import DistributedLock
+
+lock_manager = DistributedLock()
+lock = lock_manager.try_lock("process-batch")
+if lock:
+    try:
+        for chunk in get_chunks():
+            process(chunk)
+            if not lock.refresh():  # call before 20s expires
+                raise RuntimeError("Lost lock")
+    finally:
+        lock.unlock()
+```
+
+Locks auto-expire after 20 seconds if not refreshed. Only one replica can hold a given lock at a time. Call `refresh()` periodically for long-running work and always check its return value.
+
 ## Logging
 
 To ensure your logs are emitted to properly we recommend you use the `get_logger` utility function provided by the SDK. This returns a normal `logging.Logger` instance so once you have the logger, you can use it as a drop-in replacement for `logging.getLogger`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/palantir/python-compute-module"
 keywords = ["Palantir", "Foundry", "Compute Modules"]
-packages = [{ include = "compute_modules" }]
+packages = [{ include = "compute_modules" }, { include = "scratch" }]
 
 [tool.poetry.dependencies]
 python = "^3.10"
@@ -18,6 +18,7 @@ pyyaml = { version = "^6.0.1", optional = true }
 
 [tool.poetry.extras]
 sources = ["external-systems", "pyyaml"]
+scratch = ["pyyaml"]
 
 
 [tool.poetry.group.dev.dependencies]

--- a/scratch/__init__.py
+++ b/scratch/__init__.py
@@ -1,0 +1,24 @@
+#  Copyright 2026 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from scratch._cache import DistributedCache
+from scratch._lock import DistributedLock, Lock
+from scratch._types import CacheTTL
+
+__all__ = [
+    "CacheTTL",
+    "DistributedCache",
+    "DistributedLock",
+    "Lock",
+]

--- a/scratch/_cache.py
+++ b/scratch/_cache.py
@@ -1,0 +1,67 @@
+#  Copyright 2026 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""DistributedCache — the main user-facing class for caching operations."""
+
+from typing import Optional
+
+from scratch._client import _get_default_client
+from scratch._types import CacheTTL
+
+
+class DistributedCache:
+    """A distributed cache shared across all replicas of a compute module. The cache is scoped to the compute module
+    so it cannot be accessed by another compute module.
+
+    Note that data expires after a configurable TTL (default 1 hour, max 24 hours)
+    and carries no durability guarantees.
+
+    Example of a basic read-through pattern (check cache, fall back to source)::
+
+        from scratch import DistributedCache, CacheTTL
+        import json
+
+        cache = DistributedCache()
+
+        key = "expensive-result"
+        cached = cache.get(key)
+        if cached is None:
+            result = expensive_computation()
+            cache.put(key, json.dumps(result), ttl=CacheTTL.ONE_HOUR)
+        else:
+            result = json.loads(cached)
+    """
+
+    def __init__(self) -> None:
+        self._client = _get_default_client()
+
+    def get(self, key: str) -> Optional[str]:
+        """Retrieve a cached value. Returns None if the key does not exist or has expired."""
+        return self._client.get(key)
+
+    def put(self, key: str, value: str, ttl: CacheTTL = CacheTTL.ONE_HOUR) -> None:
+        """Write a value to the cache. Overwrites if exists."""
+        self._client.put(key, value, ttl)
+
+    def delete(self, key: str) -> None:
+        """Remove a key from the cache. No-op if absent."""
+        self._client.delete(key)
+
+    def exists(self, key: str) -> bool:
+        """Check if a key exists without retrieving the value."""
+        return self._client.exists(key)
+
+    def batch_get(self, keys: list[str]) -> dict[str, str]:
+        """Retrieve multiple keys in one call (max 100). Missing keys omitted."""
+        return self._client.batch_get(keys)

--- a/scratch/_cache.py
+++ b/scratch/_cache.py
@@ -32,27 +32,31 @@ class DistributedCache:
         from scratch import DistributedCache, CacheTTL
         import json
 
-        cache = DistributedCache()
+        cache = DistributedCache(default_ttl=CacheTTL.FIVE_MINUTES)
 
         key = "expensive-result"
         cached = cache.get(key)
         if cached is None:
             result = expensive_computation()
-            cache.put(key, json.dumps(result), ttl=CacheTTL.ONE_HOUR)
+            cache.put(key, json.dumps(result))
         else:
             result = json.loads(cached)
     """
 
-    def __init__(self) -> None:
+    def __init__(self, default_ttl: CacheTTL = CacheTTL.ONE_HOUR) -> None:
         self._client = _get_default_client()
+        self._default_ttl = default_ttl
 
     def get(self, key: str) -> Optional[str]:
         """Retrieve a cached value. Returns None if the key does not exist or has expired."""
         return self._client.get(key)
 
-    def put(self, key: str, value: str, ttl: CacheTTL = CacheTTL.ONE_HOUR) -> None:
-        """Write a value to the cache. Overwrites if exists."""
-        self._client.put(key, value, ttl)
+    def put(self, key: str, value: str, ttl: Optional[CacheTTL] = None) -> None:
+        """Write a value to the cache. Overwrites if exists.
+
+        Uses the default TTL from the constructor unless overridden with ``ttl``.
+        """
+        self._client.put(key, value, ttl or self._default_ttl)
 
     def delete(self, key: str) -> None:
         """Remove a key from the cache. No-op if absent."""

--- a/scratch/_client.py
+++ b/scratch/_client.py
@@ -1,0 +1,174 @@
+#  Copyright 2026 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import json
+import logging
+import os
+from functools import cache
+from typing import Any, Optional
+
+import requests
+
+from scratch._types import CacheError, CacheTTL, CacheUnavailableError, RateLimitedError, ScratchNotEnabledError
+
+LOGGER = logging.getLogger(__name__)
+
+SCRATCH_TOKEN = "SCRATCH_TOKEN"
+
+
+@cache
+def _get_default_client() -> "ScratchClient":
+    if not os.environ.get(SCRATCH_TOKEN):
+        raise ScratchNotEnabledError(
+            "Scratch cache is not enabled for this compute module. "
+            "Enable the scratch feature flag for this deployment to use it."
+        )
+    return ScratchClient()
+
+
+class ScratchClient:
+    """Low-level HTTP client for the Scratch Conjure API.
+
+    Identity is extracted server-side from the HMAC token in the Authorization header.
+    """
+
+    _CA_PATH_ENV = "CONNECTIONS_TO_OTHER_PODS_CA_PATH"
+
+    def __init__(self) -> None:
+        self._service_url = self._resolve_service_url().rstrip("/")
+
+        if not self._service_url:
+            raise CacheError(
+                "Scratch service URL not configured. Ensure FOUNDRY_SERVICE_DISCOVERY_V2 is set."
+            )
+
+        self._cert_path = os.environ.get(self._CA_PATH_ENV, "")
+        self._session = requests.Session()
+        self._session.verify = self._cert_path if self._cert_path else True
+
+    @staticmethod
+    def _resolve_service_url() -> str:
+        try:
+            import yaml  # type: ignore[import-untyped]
+        except ImportError:
+            raise ImportError(
+                "the scratch extras is not installed. Please install it with "
+                "`pip install foundry-compute-modules[scratch]`"
+            )
+
+        discovery_path = os.environ.get("FOUNDRY_SERVICE_DISCOVERY_V2", "")
+        if discovery_path and os.path.exists(discovery_path):
+            try:
+                with open(discovery_path, "r") as f:
+                    service_discovery = yaml.safe_load(f)
+                    uris: list[str] = service_discovery.get("contour_backend_multiplexer", [])
+                    if uris:
+                        return uris[0]
+            except Exception as e:
+                LOGGER.warning("Failed to parse service discovery file %s: %s", discovery_path, e)
+        return ""
+
+    def _headers(self) -> dict:
+        return {
+            "Authorization": os.environ.get(SCRATCH_TOKEN, ""),
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    def _handle_response(self, resp: requests.Response) -> Any:
+        if resp.status_code == 429:
+            raise RateLimitedError()
+        if resp.status_code == 403:
+            raise CacheError("Scratch cache is disabled or the auth token is invalid.")
+        if resp.status_code == 404:
+            raise CacheError("Scratch cache is disabled. The cache endpoint was not found.")
+        if resp.status_code >= 500:
+            raise CacheUnavailableError(f"Cache service error: {resp.status_code}")
+        resp.raise_for_status()
+        if resp.status_code == 204 or not resp.content:
+            return None
+        return resp.json()
+
+    def _url(self, path: str) -> str:
+        return f"{self._service_url}/scratch/api{path}"
+
+    # ── Cache operations ──
+
+    def get(self, key: str) -> Optional[str]:
+        resp = self._session.post(self._url("/v1/cache/get"), headers=self._headers(), data=json.dumps({"key": key}))
+        data = self._handle_response(resp)
+        if data is None:
+            return None
+        return data.get("value")
+
+    def put(self, key: str, value: str, ttl: Optional[CacheTTL] = None) -> None:
+        body = {"key": key, "value": {"value": value}}
+        if ttl is not None:
+            body["ttl"] = ttl.value
+        resp = self._session.post(self._url("/v1/cache"), headers=self._headers(), data=json.dumps(body))
+        self._handle_response(resp)
+
+    def delete(self, key: str) -> None:
+        resp = self._session.post(
+            self._url("/v1/cache/delete"), headers=self._headers(), data=json.dumps({"key": key})
+        )
+        self._handle_response(resp)
+
+    def exists(self, key: str) -> bool:
+        resp = self._session.post(
+            self._url("/v1/cache/exists"), headers=self._headers(), data=json.dumps({"key": key})
+        )
+        data = self._handle_response(resp)
+        if data is None:
+            return False
+        return data.get("exists", False)
+
+    def batch_get(self, keys: list[str]) -> dict[str, str]:
+        if len(keys) > 100:
+            raise ValueError(f"batch_get supports at most 100 keys, got {len(keys)}")
+        resp = self._session.post(
+            self._url("/v1/cache/batch-get"), headers=self._headers(), data=json.dumps({"keys": keys})
+        )
+        data = self._handle_response(resp)
+        if data is None:
+            return {}
+        entries = data.get("entries", {})
+        return {k: v["value"] for k, v in entries.items()}
+
+    # ── Lock operations ──
+
+    def try_lock(self, lock_name: str) -> Optional[dict]:
+        resp = self._session.post(
+            self._url("/v1/lock/try-lock"), headers=self._headers(), data=json.dumps({"lockName": lock_name})
+        )
+        data = self._handle_response(resp)
+        if data is not None and "acquired" in data:
+            return data["acquired"]
+        return None
+
+    def unlock(self, handle: dict) -> None:
+        resp = self._session.post(
+            self._url("/v1/lock/unlock"), headers=self._headers(), data=json.dumps({"handle": handle})
+        )
+        self._handle_response(resp)
+
+    def refresh_lock(self, handle: dict) -> bool:
+        resp = self._session.post(
+            self._url("/v1/lock/refresh"), headers=self._headers(), data=json.dumps({"handle": handle})
+        )
+        data = self._handle_response(resp)
+        if data is None:
+            return False
+        return data.get("success", False)

--- a/scratch/_client.py
+++ b/scratch/_client.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 
-import json
 import logging
 import os
 from functools import cache
@@ -83,7 +82,6 @@ class ScratchClient:
     def _headers(self) -> dict:
         return {
             "Authorization": os.environ.get(SCRATCH_TOKEN, ""),
-            "Content-Type": "application/json",
             "Accept": "application/json",
         }
 
@@ -107,7 +105,7 @@ class ScratchClient:
     # ── Cache operations ──
 
     def get(self, key: str) -> Optional[str]:
-        resp = self._session.post(self._url("/v1/cache/get"), headers=self._headers(), data=json.dumps({"key": key}))
+        resp = self._session.post(self._url("/v1/cache/get"), headers=self._headers(), json={"key": key})
         data = self._handle_response(resp)
         if data is None:
             return None
@@ -117,18 +115,18 @@ class ScratchClient:
         body = {"key": key, "value": {"value": value}}
         if ttl is not None:
             body["ttl"] = ttl.value
-        resp = self._session.post(self._url("/v1/cache"), headers=self._headers(), data=json.dumps(body))
+        resp = self._session.post(self._url("/v1/cache"), headers=self._headers(), json=body)
         self._handle_response(resp)
 
     def delete(self, key: str) -> None:
         resp = self._session.post(
-            self._url("/v1/cache/delete"), headers=self._headers(), data=json.dumps({"key": key})
+            self._url("/v1/cache/delete"), headers=self._headers(), json={"key": key}
         )
         self._handle_response(resp)
 
     def exists(self, key: str) -> bool:
         resp = self._session.post(
-            self._url("/v1/cache/exists"), headers=self._headers(), data=json.dumps({"key": key})
+            self._url("/v1/cache/exists"), headers=self._headers(), json={"key": key}
         )
         data = self._handle_response(resp)
         if data is None:
@@ -139,7 +137,7 @@ class ScratchClient:
         if len(keys) > 100:
             raise ValueError(f"batch_get supports at most 100 keys, got {len(keys)}")
         resp = self._session.post(
-            self._url("/v1/cache/batch-get"), headers=self._headers(), data=json.dumps({"keys": keys})
+            self._url("/v1/cache/batch-get"), headers=self._headers(), json={"keys": keys}
         )
         data = self._handle_response(resp)
         if data is None:
@@ -151,7 +149,7 @@ class ScratchClient:
 
     def try_lock(self, lock_name: str) -> Optional[dict]:
         resp = self._session.post(
-            self._url("/v1/lock/try-lock"), headers=self._headers(), data=json.dumps({"lockName": lock_name})
+            self._url("/v1/lock/try-lock"), headers=self._headers(), json={"lockName": lock_name}
         )
         data = self._handle_response(resp)
         if data is not None and "acquired" in data:
@@ -160,13 +158,13 @@ class ScratchClient:
 
     def unlock(self, handle: dict) -> None:
         resp = self._session.post(
-            self._url("/v1/lock/unlock"), headers=self._headers(), data=json.dumps({"handle": handle})
+            self._url("/v1/lock/unlock"), headers=self._headers(), json={"handle": handle}
         )
         self._handle_response(resp)
 
     def refresh_lock(self, handle: dict) -> bool:
         resp = self._session.post(
-            self._url("/v1/lock/refresh"), headers=self._headers(), data=json.dumps({"handle": handle})
+            self._url("/v1/lock/refresh"), headers=self._headers(), json={"handle": handle}
         )
         data = self._handle_response(resp)
         if data is None:

--- a/scratch/_lock.py
+++ b/scratch/_lock.py
@@ -26,7 +26,10 @@ class Lock:
 
     For example::
 
-        lock = lock_service.try_lock("my-lock")
+        from scratch import DistributedLock
+
+        lock_manager = DistributedLock()
+        lock = lock_manager.try_lock("my-lock")
         if lock:
             try:
                 for item in items:
@@ -87,9 +90,12 @@ class DistributedLock:
     Call ``refresh()`` periodically for long-running work, and always check its
     return value — ``False`` means the lock was lost.
 
-    For example:
+    For example::
 
-        lock = lock_service.try_lock("process-batch")
+        from scratch import DistributedLock
+
+        lock_manager = DistributedLock()
+        lock = lock_manager.try_lock("process-batch")
         if lock:
             try:
                 for chunk in get_chunks():

--- a/scratch/_lock.py
+++ b/scratch/_lock.py
@@ -1,0 +1,116 @@
+#  Copyright 2026 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+from typing import Optional
+
+from scratch._client import ScratchClient, _get_default_client
+
+
+class Lock:
+    """A held distributed lock. Expires after 20 seconds unless ``refresh()`` is called.
+
+    **Important:** The lock starts expiring immediately after acquisition. If your work
+    takes longer than 20 seconds, you must call ``refresh()`` periodically to keep it alive.
+
+    For example::
+
+        lock = lock_service.try_lock("my-lock")
+        if lock:
+            try:
+                for item in items:
+                    process(item)
+                    if not lock.refresh():  # call before 20s expires
+                        raise RuntimeError("Lost lock")
+            finally:
+                lock.unlock()
+    """
+
+    def __init__(self, client: ScratchClient, handle: dict) -> None:
+        self._client = client
+        self._handle = handle
+        self._released = False
+
+    @property
+    def lock_name(self) -> str:
+        return self._handle["lockName"]
+
+    @property
+    def lock_id(self) -> str:
+        return self._handle["lockId"]
+
+    def unlock(self) -> None:
+        """Release the lock. No-op if already released."""
+        if not self._released:
+            self._client.unlock(self._handle)
+            self._released = True
+
+    def refresh(self) -> bool:
+        """Extend the lease by another 20 seconds. Call this before the current lease expires.
+
+        Returns True if the lease was extended, False if the lock was lost (e.g. it expired
+        before this call reached the server). Always check the return value.
+        """
+        if self._released:
+            return False
+        return self._client.refresh_lock(self._handle)
+
+    def __enter__(self) -> "Lock":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.unlock()
+
+
+class DistributedLock:
+    """Distributed locking for cross-replica coordination.
+
+    Locks auto-expire after 20 seconds if not refreshed. Only one replica
+    can hold a given lock at a time.
+
+    **Lock safety:** A lock does not guarantee mutual exclusion forever. If a
+    replica acquires a lock but then stalls (GC pause, network hiccup, slow I/O),
+    the lock will expire after the TTL and another replica can acquire it.
+    The lock TTL is short by design (20s) to avoid situations where the holder dies
+    (e.g. OOM) and the lock cannot be acquired by any other living replica.
+    Call ``refresh()`` periodically for long-running work, and always check its
+    return value — ``False`` means the lock was lost.
+
+    For example:
+
+        lock = lock_service.try_lock("process-batch")
+        if lock:
+            try:
+                for chunk in get_chunks():
+                    process(chunk)
+                    if not lock.refresh():
+                        raise RuntimeError("Lost lock — another replica took over")
+            finally:
+                lock.unlock()
+    """
+
+    def __init__(self) -> None:
+        self._client = _get_default_client()
+
+    def try_lock(self, lock_name: str) -> Optional[Lock]:
+        """Attempt to acquire a named lock.
+
+        Returns a ``Lock`` if acquired, ``None`` if the lock is held by another client.
+        The lock starts its 20-second TTL immediately, so you must call ``lock.refresh()`` for
+        long-running work
+        """
+        handle = self._client.try_lock(lock_name)
+        if handle is None:
+            return None
+        return Lock(self._client, handle)

--- a/scratch/_types.py
+++ b/scratch/_types.py
@@ -1,0 +1,49 @@
+#  Copyright 2026 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from enum import Enum
+
+
+class CacheTTL(Enum):
+    """Allowed TTL values for cache entries.
+
+    Enforces the maximum 24-hour TTL and prevents runtime errors from invalid durations.
+    """
+
+    ONE_MINUTE = "ONE_MINUTE"
+    FIVE_MINUTES = "FIVE_MINUTES"
+    FIFTEEN_MINUTES = "FIFTEEN_MINUTES"
+    ONE_HOUR = "ONE_HOUR"
+    SIX_HOURS = "SIX_HOURS"
+    TWELVE_HOURS = "TWELVE_HOURS"
+    ONE_DAY = "ONE_DAY"
+
+
+class CacheError(Exception):
+    """Base exception for cache operations."""
+
+
+class ScratchNotEnabledError(CacheError):
+    """Raised when scratch cache is not enabled for this compute module."""
+
+
+class CacheUnavailableError(CacheError):
+    """Raised when the cache service is unreachable."""
+
+
+class RateLimitedError(CacheError):
+    """Raised when the rate limit is exceeded."""
+
+    def __init__(self) -> None:
+        super().__init__("Rate limit exceeded for this compute module.")

--- a/tests/cache/conftest.py
+++ b/tests/cache/conftest.py
@@ -1,0 +1,31 @@
+#  Copyright 2026 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Generator
+from unittest.mock import MagicMock
+
+import pytest
+
+from scratch._client import ScratchClient, _get_default_client
+
+
+@pytest.fixture(autouse=True)
+def clear_default_client_cache() -> Generator[None, None, None]:
+    yield
+    _get_default_client.cache_clear()
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    return MagicMock(spec=ScratchClient)

--- a/tests/cache/test_cache.py
+++ b/tests/cache/test_cache.py
@@ -1,0 +1,46 @@
+#  Copyright 2026 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from unittest.mock import MagicMock, patch
+
+from scratch._cache import DistributedCache
+from scratch._types import CacheTTL
+
+
+@patch("scratch._cache._get_default_client")
+class TestDistributedCache:
+    def test_get(self, mock_get_client: MagicMock) -> None:
+        mock_get_client.return_value.get.return_value = "cached-value"
+        assert DistributedCache().get("my-key") == "cached-value"
+        mock_get_client.return_value.get.assert_called_once_with("my-key")
+
+    def test_put_default_ttl(self, mock_get_client: MagicMock) -> None:
+        DistributedCache().put("k", "v")
+        mock_get_client.return_value.put.assert_called_once_with("k", "v", CacheTTL.ONE_HOUR)
+
+    def test_put_custom_ttl(self, mock_get_client: MagicMock) -> None:
+        DistributedCache().put("k", "v", CacheTTL.FIVE_MINUTES)
+        mock_get_client.return_value.put.assert_called_once_with("k", "v", CacheTTL.FIVE_MINUTES)
+
+    def test_delete(self, mock_get_client: MagicMock) -> None:
+        DistributedCache().delete("k")
+        mock_get_client.return_value.delete.assert_called_once_with("k")
+
+    def test_exists(self, mock_get_client: MagicMock) -> None:
+        mock_get_client.return_value.exists.return_value = True
+        assert DistributedCache().exists("k") is True
+
+    def test_batch_get(self, mock_get_client: MagicMock) -> None:
+        mock_get_client.return_value.batch_get.return_value = {"a": "1", "b": "2"}
+        assert DistributedCache().batch_get(["a", "b"]) == {"a": "1", "b": "2"}

--- a/tests/cache/test_client.py
+++ b/tests/cache/test_client.py
@@ -1,0 +1,196 @@
+#  Copyright 2026 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Optional
+from unittest import mock
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from scratch._client import ScratchClient, _get_default_client
+from scratch._types import CacheError, CacheTTL, CacheUnavailableError, RateLimitedError, ScratchNotEnabledError
+
+
+def _make_response(status_code: int = 200, body: Optional[dict[str, Any]] = None) -> MagicMock:
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    if body is not None:
+        resp.content = json.dumps(body).encode()
+        resp.json.return_value = body
+    else:
+        resp.content = b""
+    return resp
+
+
+@pytest.fixture
+def client() -> ScratchClient:
+    with patch.object(ScratchClient, "_resolve_service_url", return_value="https://scratch.local"):
+        return ScratchClient()
+
+
+def _stub_post(client: ScratchClient, resp: MagicMock) -> MagicMock:
+    post_mock = MagicMock(return_value=resp)
+    client._session.post = post_mock  # type: ignore[method-assign]
+    return post_mock
+
+
+def _posted_body(post_mock: MagicMock) -> Any:
+    return json.loads(post_mock.call_args[1]["data"])
+
+
+def test_get_default_client_no_token() -> None:
+    with mock.patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ScratchNotEnabledError, match="not enabled"):
+            _get_default_client()
+
+
+def test_get_default_client_caches() -> None:
+    with mock.patch.dict(os.environ, {"SCRATCH_TOKEN": "test-token"}, clear=True):
+        with patch.object(ScratchClient, "_resolve_service_url", return_value="https://scratch.local"):
+            assert _get_default_client() is _get_default_client()
+
+
+def test_resolve_service_url_from_yaml(tmp_path: Path) -> None:
+    service_file = tmp_path / "sd.yaml"
+    service_file.write_text("contour_backend_multiplexer:\n  - https://scratch.local\n  - https://backup.local\n")
+
+    mock_yaml = MagicMock()
+    mock_yaml.safe_load.return_value = {
+        "contour_backend_multiplexer": ["https://scratch.local", "https://backup.local"]
+    }
+
+    with mock.patch.dict(os.environ, {"FOUNDRY_SERVICE_DISCOVERY_V2": str(service_file)}):
+        with patch.dict("sys.modules", {"yaml": mock_yaml}):
+            assert ScratchClient._resolve_service_url() == "https://scratch.local"
+
+
+def test_resolve_service_url_missing_file() -> None:
+    mock_yaml = MagicMock()
+    with mock.patch.dict(os.environ, {"FOUNDRY_SERVICE_DISCOVERY_V2": "/nonexistent/path.yaml"}):
+        with patch.dict("sys.modules", {"yaml": mock_yaml}):
+            assert ScratchClient._resolve_service_url() == ""
+
+
+def test_resolve_service_url_no_env() -> None:
+    mock_yaml = MagicMock()
+    with mock.patch.dict(os.environ, {}, clear=True):
+        with patch.dict("sys.modules", {"yaml": mock_yaml}):
+            assert ScratchClient._resolve_service_url() == ""
+
+
+def test_init_raises_without_service_url() -> None:
+    with patch.object(ScratchClient, "_resolve_service_url", return_value=""):
+        with pytest.raises(CacheError, match="Scratch service URL not configured"):
+            ScratchClient()
+
+
+@pytest.mark.parametrize(
+    "status_code, exception_type",
+    [
+        (429, RateLimitedError),
+        (403, CacheError),
+        (404, CacheError),
+        (500, CacheUnavailableError),
+    ],
+)
+def test_handle_response_errors(client: ScratchClient, status_code: int, exception_type: type) -> None:
+    with pytest.raises(exception_type):
+        client._handle_response(_make_response(status_code))
+
+
+def test_handle_response_204(client: ScratchClient) -> None:
+    assert client._handle_response(_make_response(204)) is None
+
+
+def test_handle_response_200_json(client: ScratchClient) -> None:
+    assert client._handle_response(_make_response(200, {"key": "val"})) == {"key": "val"}
+
+
+def test_url_construction(client: ScratchClient) -> None:
+    assert client._url("/v1/cache/get") == "https://scratch.local/scratch/api/v1/cache/get"
+
+
+def test_get(client: ScratchClient) -> None:
+    post = _stub_post(client, _make_response(200, {"value": "hello"}))
+
+    assert client.get("my-key") == "hello"
+    assert "/v1/cache/get" in post.call_args[0][0]
+    assert _posted_body(post) == {"key": "my-key"}
+
+
+def test_get_miss(client: ScratchClient) -> None:
+    _stub_post(client, _make_response(204))
+    assert client.get("missing") is None
+
+
+def test_put_with_ttl(client: ScratchClient) -> None:
+    post = _stub_post(client, _make_response(204))
+    client.put("k", "v", CacheTTL.FIVE_MINUTES)
+    assert _posted_body(post) == {"key": "k", "value": {"value": "v"}, "ttl": "FIVE_MINUTES"}
+
+
+def test_put_without_ttl(client: ScratchClient) -> None:
+    post = _stub_post(client, _make_response(204))
+    client.put("k", "v")
+    assert "ttl" not in _posted_body(post)
+
+
+def test_delete(client: ScratchClient) -> None:
+    post = _stub_post(client, _make_response(204))
+    client.delete("k")
+    assert _posted_body(post) == {"key": "k"}
+
+
+@pytest.mark.parametrize("exists", [True, False])
+def test_exists(client: ScratchClient, exists: bool) -> None:
+    _stub_post(client, _make_response(200, {"exists": exists}))
+    assert client.exists("k") is exists
+
+
+def test_batch_get(client: ScratchClient) -> None:
+    _stub_post(client, _make_response(200, {"entries": {"a": {"value": "1"}, "b": {"value": "2"}}}))
+    assert client.batch_get(["a", "b"]) == {"a": "1", "b": "2"}
+
+
+def test_batch_get_over_100(client: ScratchClient) -> None:
+    with pytest.raises(ValueError, match="at most 100"):
+        client.batch_get([f"key-{i}" for i in range(101)])
+
+
+def test_try_lock_acquired(client: ScratchClient) -> None:
+    handle = {"lockName": "my-lock", "lockId": "abc123"}
+    _stub_post(client, _make_response(200, {"acquired": handle}))
+    assert client.try_lock("my-lock") == handle
+
+
+def test_try_lock_not_acquired(client: ScratchClient) -> None:
+    _stub_post(client, _make_response(200, {"notAcquired": {}}))
+    assert client.try_lock("my-lock") is None
+
+
+def test_unlock(client: ScratchClient) -> None:
+    handle = {"lockName": "my-lock", "lockId": "abc123"}
+    post = _stub_post(client, _make_response(204))
+    client.unlock(handle)
+    assert _posted_body(post) == {"handle": handle}
+
+
+@pytest.mark.parametrize("success", [True, False])
+def test_refresh_lock(client: ScratchClient, success: bool) -> None:
+    _stub_post(client, _make_response(200, {"success": success}))
+    assert client.refresh_lock({"lockName": "l", "lockId": "i"}) is success

--- a/tests/cache/test_client.py
+++ b/tests/cache/test_client.py
@@ -50,7 +50,7 @@ def _stub_post(client: ScratchClient, resp: MagicMock) -> MagicMock:
 
 
 def _posted_body(post_mock: MagicMock) -> Any:
-    return json.loads(post_mock.call_args[1]["data"])
+    return post_mock.call_args[1]["json"]
 
 
 def test_get_default_client_no_token() -> None:

--- a/tests/cache/test_lock.py
+++ b/tests/cache/test_lock.py
@@ -1,0 +1,78 @@
+#  Copyright 2026 Palantir Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from unittest.mock import MagicMock, patch
+
+from scratch._lock import DistributedLock, Lock
+
+HANDLE = {"lockName": "my-lock", "lockId": "abc123"}
+
+
+class TestLock:
+    def test_properties(self, mock_client: MagicMock) -> None:
+        lock = Lock(mock_client, HANDLE)
+        assert lock.lock_name == "my-lock"
+        assert lock.lock_id == "abc123"
+
+    def test_unlock(self, mock_client: MagicMock) -> None:
+        lock = Lock(mock_client, HANDLE)
+        lock.unlock()
+        mock_client.unlock.assert_called_once_with(HANDLE)
+
+    def test_unlock_idempotent(self, mock_client: MagicMock) -> None:
+        lock = Lock(mock_client, HANDLE)
+        lock.unlock()
+        lock.unlock()
+        mock_client.unlock.assert_called_once()
+
+    def test_refresh(self, mock_client: MagicMock) -> None:
+        mock_client.refresh_lock.return_value = True
+        lock = Lock(mock_client, HANDLE)
+        assert lock.refresh() is True
+        mock_client.refresh_lock.assert_called_once_with(HANDLE)
+
+    def test_refresh_after_release_returns_false(self, mock_client: MagicMock) -> None:
+        lock = Lock(mock_client, HANDLE)
+        lock.unlock()
+        assert lock.refresh() is False
+        mock_client.refresh_lock.assert_not_called()
+
+    def test_context_manager(self, mock_client: MagicMock) -> None:
+        with Lock(mock_client, HANDLE):
+            pass
+        mock_client.unlock.assert_called_once_with(HANDLE)
+
+    def test_context_manager_unlocks_on_exception(self, mock_client: MagicMock) -> None:
+        try:
+            with Lock(mock_client, HANDLE):
+                raise ValueError("boom")
+        except ValueError:
+            pass
+        mock_client.unlock.assert_called_once_with(HANDLE)
+
+
+class TestDistributedLock:
+    @patch("scratch._lock._get_default_client")
+    def test_try_lock_acquired(self, mock_get_client: MagicMock) -> None:
+        mock_get_client.return_value.try_lock.return_value = HANDLE
+
+        lock = DistributedLock().try_lock("my-lock")
+
+        assert isinstance(lock, Lock)
+        assert lock.lock_name == "my-lock"
+
+    @patch("scratch._lock._get_default_client")
+    def test_try_lock_not_acquired(self, mock_get_client: MagicMock) -> None:
+        mock_get_client.return_value.try_lock.return_value = None
+        assert DistributedLock().try_lock("my-lock") is None


### PR DESCRIPTION
## After this PR
Adds a scratch Python package, providing DistributedCache and DistributedLock classes for compute modules to use the scratch service.                                       
   
 Package structure:                                                                                                                                                                                             
  - scratch/_types.py: CacheTTL enum, exception hierarchy (CacheError, ScratchNotEnabledError, CacheUnavailableError, RateLimitedError)                                                                       
  - scratch/_client.py: ScratchClient low-level HTTP client (service discovery via FOUNDRY_SERVICE_DISCOVERY_V2, auth via SCRATCH_TOKEN)                                                                        
  - scratch/_cache.py: DistributedCache user-facing class (get, put, delete, exists, batch_get)
  - scratch/_lock.py: DistributedLock + Lock user-facing classes (try_lock, unlock, refresh, context manager)                                                                                                   
                                                                                                                                                                                                               
  Feature gating:                                                                                                                                                                                                
  - DistributedCache() and DistributedLock() raise ScratchNotEnabledError at construction time if the SCRATCH_TOKEN env var is not present (injected by to the CM when scratch is enabled on the stack/for the compute module)                                                                                                                       
                                                                                                                                                                                                                 
  Service discovery:                                                                                                                                                                                             
  - Resolves the scratch service URL from FOUNDRY_SERVICE_DISCOVERY_V2 (compute mesh), reading the contour_backend_multiplexer entry                                                                           
  - A service_url constructor param is available as override for testing                                                                                                                                         
   
Note: The URL paths (/scratch/api/v1/cache, /scratch/api/v1/lock/...) are currently hardcoded in the client. This is consistent with how internal_query_client.py handles its endpoints in this SDK. If scratch is extracted into a shared package in the future, these could be replaced with a generated Conjure Python client, but should be fine for v0.                 

==COMMIT_MSG==
Add Scratch package
==COMMIT_MSG==


